### PR TITLE
v1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "o-ads",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "main": [
     "main.scss",
     "main.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o-ads",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "description": "FT branded Advertising Client-side Library",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
o-ads is used in production and should use v1.0.0

Pre-v1.0.0 releases in semver are a real pain to manage for us.