### PR TITLE
Adds the ad format loaded to the slot as an attribute (ADS-754)

### DIFF
--- a/docs/SLOT_CONFIG_REFERENCE.md
+++ b/docs/SLOT_CONFIG_REFERENCE.md
@@ -174,6 +174,7 @@ The library comes with the following default options:
 
 ***Note:*** Formats can only be configured via JSON configuration. Also once added, they can be used a number of slots alongside the default formats. Also the formats are a global configuration, and you cannot define a format per slot and re-use it on other slots.
 
+Once the advert is loaded, an attribute called `data-o-ads-loaded` will be added to the slot, with the name of the ad format that was actually loaded into the slot.
 
 #### JSON Configuration
 ```js

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -257,6 +257,14 @@ Slot.prototype.collapse = function() {
 };
 
 /**
+* sets a classname of the format
+*/
+Slot.prototype.setFormatLoaded = function(format) {
+	this.container.setAttribute('data-o-ads-loaded', format);
+	return this;
+};
+
+/**
 * remove the empty class from the slot
 */
 Slot.prototype.uncollapse = function() {

--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -56,6 +56,19 @@ function run(slots, action, name) {
 	}
 }
 
+function findFormatBySize(size) {
+	if(!size) {
+		return false;
+	}
+	var formats = config('formats');
+	for(var prop in formats) {
+		/* istanbul ignore else  */
+		if(formats.hasOwnProperty(prop)) {
+			if( formats[prop].sizes[0] === parseInt(size[0]) && formats[prop].sizes[1] === parseInt(size[1]))
+				return prop;
+			}
+		}
+}
 /**
 * Given a slot name or an array of slot names will collapse the slots using the collapse method on the slot
 */
@@ -202,6 +215,8 @@ Slots.prototype.initRendered = function() {
 		if (slot) {
 			utils.extend(slot[slot.server], event.detail[slot.server]);
 			var size = event.detail.gpt.size;
+			var format = findFormatBySize(size);
+			slot.setFormatLoaded(format);
 			slot.maximise(size);
 			slot.fire('complete', event.detail);
 		}

--- a/test/qunit/mocks/gpt-mock.js
+++ b/test/qunit/mocks/gpt-mock.js
@@ -77,7 +77,6 @@ function slotRender(slot, color) {
 
 	var trackingDiv = slot.hasOwnProperty('_testAdTrackingDiv') ? '<div id="tracking" data-o-ads-impression-url="https://www.ft.com"></div>' : '';
 	var html = 'javascript:\'<html><body style="background:' + color + ';">'+trackingDiv+'</body></html>\'';
-
 	if (slot.responsive) {
 		size = getResponsiveSizes(slot.sizes)[0];
 	} else {
@@ -168,6 +167,7 @@ stubs.stub(pubads, 'addEventListener', function(eventName, fn) {
 stubs.stub(pubads, 'refresh', function(slots) {
 	slots.forEach(function(slot) {
 		slotRender(slot.id, '#006D91');
+		slotRenderEnded(slot.id);
 	});
 	return slots;
 });

--- a/test/qunit/slots.test.js
+++ b/test/qunit/slots.test.js
@@ -196,6 +196,7 @@ QUnit.test('responsive slot should refresh when a new size exists for a breakpoi
 	var clock = this.date();
 	this.viewport(700, 700);
 
+
 	var slotHTML = '<div data-o-ads-name="mpu" data-o-ads-formats-large="Leaderboard"  data-o-ads-formats-medium="MediumRectangle"  data-o-ads-formats-small="false"></div>';
 	var node = this.fixturesContainer.add(slotHTML);
 	this.ads.init({
@@ -211,12 +212,13 @@ QUnit.test('responsive slot should refresh when a new size exists for a breakpoi
 	assert.ok(this.gpt.display.calledOnce, 'Initial ad call is made for large size.');
 	var iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
 	assert.deepEqual(iframeSize, ['728', '90'], 'The ad slot is displayed at the correct size.');
-
+	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'Leaderboard');
 	this.viewport(500, 500);
 	window.dispatchEvent(new Event('resize'));
 	clock.tick(300);
 	assert.ok(this.gpt.pubads().refresh.calledOnce, 'When screen size is changed, ad call is made.');
 	iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
+	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'MediumRectangle');
 	assert.deepEqual(iframeSize, ['300', '250'], 'The new size is displayed.');
 });
 


### PR DESCRIPTION
/cc @VladDubrovskis @andrewgeorgiou1981 (ADS-754)

Adds a data attribute to the element with the name of the format loaded e.g. `data-o-ads-loaded="Responsive"`.

This is so we can target that in CSS and give e.g. different padding to responsive creatives.