### PR TITLE
Fix for ads getting cut off when resized

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -250,7 +250,10 @@ function onRenderEnded(event) {
 	detail.lineItemId = event.lineItemId;
 	detail.serviceName = event.serviceName;
 	detail.iframe = document.getElementById(iframeId);
-
+	if(detail.size) {
+		detail.iframe.style.width = detail.size[0] + 'px';
+		detail.iframe.style.height = detail.size[1] + 'px';
+	}
 	utils.broadcast('rendered', data);
 }
 

--- a/test/qunit/gpt.test.js
+++ b/test/qunit/gpt.test.js
@@ -169,6 +169,20 @@ QUnit.test('catches slot in view render event and display it if method is ready'
 	assert.ok(displaySpy.calledOnce, 'slot dislpay method has been triggered');
 });
 
+QUnit.test('on slot refresh event sets the iframe width and height', function(assert) {
+	var done = assert.async();
+	var slotHTML = '<div data-o-ads-formats="MediumRectangle"></div>';
+	var node = this.fixturesContainer.add(slotHTML);
+	this.ads.init();
+	document.body.addEventListener('oAds.rendered', function(event) {
+		var iframe = event.detail.gpt.iframe;
+		assert.equal(iframe.style.width, '300px');
+		assert.equal(iframe.style.height, '250px');
+		done();
+	});
+	var slot = this.ads.slots.initSlot(node);
+});
+
 QUnit.test('on slot refresh event updates targeting', function(assert) {
 	var slotHTML = '<div data-o-ads-formats="MediumRectangle" data-o-ads-targeting="random=1"></div>';
 	var node = this.fixturesContainer.add(slotHTML);


### PR DESCRIPTION
Not sure if there's a nicer way of doing it, but this fixes ads getting cut off when resized because the iframe has the original width/height as inline styles.

@VladDubrovskis @andrewgeorgiou1981 @leggsimon  