### PR TITLE
Use px for label font

### DIFF
--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -18,13 +18,13 @@
 	content: "▼ Advertisement ▼";
 	display: block;
 	text-align: right;
-	font-size: 80%;
+	font-size: 14px;
 }
 
 .o-ads__label-left .o-ads__inner::before {
 	content: "▼ Advertisement ▼";
 	display: block;
-	font-size: 80%;
+	font-size: 14px;
 }
 
 .o-ads,


### PR DESCRIPTION
Hunch that this might be breaking the label in IE9 @VladDubrovskis @leggsimon 