### PR TITLE
AT-85: Avoid calling slot methods on non-existent slots

### DIFF
--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -271,7 +271,7 @@ Slots.prototype.initPostMessage = function() {
 				const slotName = utils.iframeToSlotName(event.source.window);
 				slot = slots[slotName] || false;
 
-				if(slot) {
+				if (slot) {
 					if (data.collapse) {
 						slot.collapse();
 					}
@@ -287,9 +287,9 @@ Slots.prototype.initPostMessage = function() {
 						});
 					}
 
-          if(slot.disableSwipeDefault) {
-            messageToSend.disableDefaultSwipeHandler = true;
-          }
+					if(slot.disableSwipeDefault) {
+						messageToSend.disableDefaultSwipeHandler = true;
+					}
 
 					messageToSend.name = slotName;
 					messageToSend.sizes = slot.sizes;
@@ -299,16 +299,23 @@ Slots.prototype.initPostMessage = function() {
 					utils.log.error('Message received from unidentified slot');
 					utils.messenger.post(messageToSend, event.source);
 				}
-			} else if(type === 'responsive') {
-				slot.setResponsiveCreative(true);
-			} else if (utils.isFunction(slot[type])) {
-				slot[type]();
-			} else if (/^touch/.test(data.type)) {
-				slots[data.name].fire('touch', data);
 			} else {
-				delete data.type;
-				delete data.name;
-				slot.fire(type, data);
+				if (!slot) {
+					utils.log.error('Message received from unidentified slot');
+					return;
+				}
+
+				if(type === 'responsive') {
+					slot.setResponsiveCreative(true);
+				} else if (utils.isFunction(slot[type])) {
+					slot[type]();
+				} else if (/^touch/.test(data.type)) {
+					slot.fire('touch', data);
+				} else {
+					delete data.type;
+					delete data.name;
+					slot.fire(type, data);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Looks like the `slot` is false in some cases when events are fired (race conditions? Seen during page teardown) so looks sensible to me to put it all in a check that the slot is still valid...