### PR TITLE
Skip JSON.parse for things that don't look like stringified JSON objects

### DIFF
--- a/src/js/utils/messenger.js
+++ b/src/js/utils/messenger.js
@@ -11,6 +11,12 @@ module.exports.messenger = {
 		source.postMessage(message, '*');
 	},
 	parse: function(message) {
+
+		// Check whether the message looks like an object before trying to parse it
+		if (typeof message !== 'string' || message[0] !== '{') {
+			return message;
+		}
+
 		// try returning the parsed object
 		try {
 			return JSON.parse(message);


### PR DESCRIPTION
...improving JSON.parse overhead and avoid triggering try/catch debuggers.

@VladDubrovskis - I could have sworn I saw something like this elsewhere in the ads codebase already? Can't find it now though...

There's a lot of actual objects and random horribleness coming in messages from ads, tripping the debugger every frame if it's in all-errors mode, so this will silence some noise.