### PR TITLE
Delay the loading of the Krux JS

### DIFF
--- a/demos/src/individualcustomtargeting.mustache
+++ b/demos/src/individualcustomtargeting.mustache
@@ -3,6 +3,9 @@
 		"gpt": {
 			"network": {{network}},
 			"site": "{{site}}"
+		},
+		"krux": {
+			"id": "IgnVxTJW"
 		}
 	}
 </script>

--- a/docs/DATA_PROVIDERS.md
+++ b/docs/DATA_PROVIDERS.md
@@ -25,3 +25,5 @@ oAds.init({
 ```
 
 The attributes object can take user, page and custom data objects to send to Krux.
+
+The krux script is loaded when the page is idle (using `requestIdleCallback` if supported) or with a `setTimeout` of 100ms if it is not supported. An `oAds.kruxScriptLoaded` event is fired when the krux script has loaded (on it's onload callback - not necessarily when it's executed).

--- a/docs/DATA_PROVIDERS.md
+++ b/docs/DATA_PROVIDERS.md
@@ -26,4 +26,4 @@ oAds.init({
 
 The attributes object can take user, page and custom data objects to send to Krux.
 
-The krux script is loaded when the page is idle (using `requestIdleCallback` if supported) or with a `setTimeout` of 100ms if it is not supported. An `oAds.kruxScriptLoaded` event is fired when the krux script has loaded (on it's onload callback - not necessarily when it's executed).
+The krux script is loaded when the page is idle (using `requestIdleCallback` if supported) and with a `setTimeout` of 1000ms. An `oAds.kruxScriptLoaded` event is fired when the krux script has loaded (on it's onload callback - not necessarily when it's executed).

--- a/src/js/data-providers/krux.js
+++ b/src/js/data-providers/krux.js
@@ -38,9 +38,20 @@ Krux.prototype.init = function() {
 			src = decodeURIComponent(m[1]);
 		}
 		const finalSrc = /^https?:\/\/([^\/]+\.)?krxd\.net(:\d{1,5})?\//i.test(src) ? src : src === "disable" ? "" : `//cdn.krxd.net/controltag?confid=${this.config.id}`;
+		
+		const loadKruxScript = () => {
+			utils.attach(finalSrc, true, () => {
+				utils.broadcast('kruxScriptLoaded');
+			});
+			this.events.init();
+		};
 
-		utils.attach(finalSrc, true);
-		this.events.init();
+		if('requestIdleCallback' in window) {
+			requestIdleCallback(loadKruxScript);
+		} else {
+			setTimeout(loadKruxScript, 100);
+		}
+
 		targeting.add(this.targeting());
 	} else {
 		// can't initialize Krux because no Krux ID is configured, please add it as key id in krux config.

--- a/src/js/data-providers/krux.js
+++ b/src/js/data-providers/krux.js
@@ -45,12 +45,13 @@ Krux.prototype.init = function() {
 			});
 			this.events.init();
 		};
-
-		if('requestIdleCallback' in window) {
-			requestIdleCallback(loadKruxScript);
-		} else {
-			setTimeout(loadKruxScript, 100);
-		}
+		setTimeout(() => {
+			if('requestIdleCallback' in window) {
+				requestIdleCallback(loadKruxScript);
+			} else {
+				loadKruxScript();
+			}
+		}, 1000);
 
 		targeting.add(this.targeting());
 	} else {

--- a/test/qunit/krux.test.js
+++ b/test/qunit/krux.test.js
@@ -14,6 +14,8 @@ QUnit.module('Krux', {
 
 QUnit.test("control tag is attached when initialised", function(assert) {
 	this.ads.init({krux: {id: 'hello'}});
+	const clock = this.date();
+	clock.tick(1001);
 	assert.ok(this.ads.utils.attach.withArgs('oxnso'), 'the krux control tag file is attached to the page');
 });
 
@@ -26,7 +28,9 @@ QUnit.test('sets global Krux if one is not available yet', function(assert) {
 QUnit.test('adds a script from url when location contains krux src', function(assert) {
 	this.stub(this.utils, 'getLocation').returns('http://domain/?kxsrc=http%3A%2F%2Fcdn.krxd.net%3A123%2F');
 	this.stub(this.utils, 'broadcast');
+	const clock = this.date();
 	this.ads.init({ krux: {id: '112233', attributes: {page: {uuid: '123'}} }});
+	clock.tick(1001);
 	assert.ok(this.attach.calledWith('http://cdn.krxd.net:123/', true), 'the krux script has been added to the page');
 	assert.ok(this.utils.broadcast.calledWith('kruxScriptLoaded'));
 });
@@ -37,15 +41,16 @@ QUnit.test('adds Krux script after a timeout if requestIdleCallback doesn\'t exi
 	delete window.requestIdleCallback;
 	const clock = this.date();
 	this.ads.init({ krux: {id: '112233', attributes: {page: {uuid: '123'}} }});
-	assert.notOk(this.utils.broadcast.calledWith('kruxScriptLoaded'));
-	clock.tick(101);
+	clock.tick(1001);
 	assert.ok(this.attach.calledWith('http://cdn.krxd.net:123/', true), 'the krux script has been added to the page');
 	assert.ok(this.utils.broadcast.calledWith('kruxScriptLoaded'));
 });
 
 QUnit.test('does not add a script from url when location contains krux src that is set to disable', function(assert) {
 	this.stub(this.utils, 'getLocation').returns('http://domain/?kxsrc=disable');
+	const clock = this.date();
 	this.ads.init({ krux: {id: '112233', attributes: {page: {uuid: '123'}} }});
+	clock.tick(1001);
 	assert.ok(this.attach.calledWith('', true), 'the url passed to attach is empty');
 });
 
@@ -145,6 +150,8 @@ QUnit.test('event pixel - dwell time', function(assert) {
 		}
 	});
 
+	clock.tick(1001);
+
 	clock.tick(11000);
 	assert.ok(window.Krux.calledWith('admEvent', dwellTimeId, {dwell_time: 10}), 'fired after first interval');
 
@@ -182,6 +189,7 @@ QUnit.test('event pixel - dwell time defaults', function(assert) {
 		}
 	});
 
+	clock.tick(1001);
 	clock.tick(5100);
 	assert.ok(window.Krux.calledWith('admEvent', dwellTimeId, {dwell_time: 5}), 'fired after first interval');
 


### PR DESCRIPTION
/cc @VladDubrovskis @andrewgeorgiou1981 @rowanbeentje 
If Krux executes before the ad loads, it takes up valuable time on the main thread. This PR delays the loading of Krux's script by a second, and also uses requestIdleCallback if available to wait for the user to be done interacting.

Before:

![screen shot 2016-07-06 at 15 40 31](https://cloud.githubusercontent.com/assets/1978880/16622240/55357872-4391-11e6-8208-fd9b39a67253.png)


After:

<img width="961" alt="screen shot 2016-07-06 at 15 42 29" src="https://cloud.githubusercontent.com/assets/1978880/16622238/52471cd8-4391-11e6-8de8-53b6d99a5a56.png">