### PR TITLE
Fix resizing behaviour with responsive ads

### DIFF
--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -277,6 +277,7 @@ Slot.prototype.setResponsiveCreative = function (value) {
 */
 Slot.prototype.collapse = function() {
 	this.container.classList.add('o-ads--empty');
+	this.setFormatLoaded(false);
 	document.body.classList.add(`o-ads-no-${this.name}`);
 	return this;
 };
@@ -363,6 +364,7 @@ Slot.prototype.hasValidSize = function(screensize) {
 
 	return true;
 };
+
 
 /**
 * Add a center class to the main container

--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -244,7 +244,10 @@ function onBreakpointChange(slots, screensize) {
 		if (slot) {
 			// ADS-766 if format name is Responsive then we have requested a responsive creative and do not want to request new ads at different breakpoints
 			/* istanbul ignore else	*/
-			if (slot.container && slot.container.getAttribute('data-o-ads-loaded') && (slot.container.getAttribute('data-o-ads-loaded') === "Responsive") && slot.sizes[screensize] !== false) {
+			const isCurrentlyResponsive = slot.container && slot.container.getAttribute('data-o-ads-loaded') === 'Responsive';
+			const stillWantsResponsive = slot.sizes[screensize] && slot.sizes[screensize].filter(size => findFormatBySize(size) === 'Responsive').length > 0;
+
+			if (isCurrentlyResponsive && stillWantsResponsive) {
 				return false;
 			}
 			slot.screensize = screensize;

--- a/test/browser/basic/individual-ad-with-custom-targeting-values.js
+++ b/test/browser/basic/individual-ad-with-custom-targeting-values.js
@@ -19,7 +19,7 @@ module.exports = {
 				// wait for 1 second for advert to appear
 				.waitForElementPresent('img', wait, 'Advert image is visible')
 				// make sure we can see the correct URL
-				.assert.attributeContains('img', 'src', 'http://com.ft.ads-static-content.s3-website-eu-west-1.amazonaws.com/ci/o-leaderboard.png')
+				.assert.attributeContains('img', 'src', 'https://tpc.googlesyndication.com/simgad/12593654562240684097')
 				// switch focus back to main page
 				.frame(null);
 	},

--- a/test/browser/basic/individual-ad.js
+++ b/test/browser/basic/individual-ad.js
@@ -19,7 +19,7 @@ module.exports = {
 				// wait for 1 second for advert to appear
 				.waitForElementPresent('img', wait, 'Advert image is visible')
 				// make sure we can see the correct URL
-				.assert.attributeContains('img', 'src', 'https://tpc.googlesyndication.com/simgad/1809750796305150566', 'Correct image is displayed for leaderboard')
+				.assert.attributeContains('img', 'src', 'https://tpc.googlesyndication.com/simgad/10216588618324896871', 'Correct image is displayed for leaderboard')
 				// switch focus back to main page
 				.frame(null);
 	},

--- a/test/browser/extended/responsive-positions.js
+++ b/test/browser/extended/responsive-positions.js
@@ -25,7 +25,7 @@ module.exports = {
 				// wait for 1 second for advert to appear
 				.waitForElementPresent('img', wait, 'First adaptive advert image is visible')
 				// make sure we can see the correct URL
-				.assert.attributeContains('img', 'src', 'http://com.ft.ads-static-content.s3-website-eu-west-1.amazonaws.com/ci/o-leaderboard.png')
+				.assert.attributeContains('img', 'src', 'https://tpc.googlesyndication.com/simgad/12593654562240684097')
 				// switch focus back to main page
 				.frame(null);
 	},
@@ -38,7 +38,7 @@ module.exports = {
 				// wait for 1 second for advert to appear
 				.waitForElementPresent('img', wait, 'Second adaptive advert image is visible')
 				// make sure we can see the correct URL
-				.assert.attributeContains('img', 'src', 'http://com.ft.ads-static-content.s3-website-eu-west-1.amazonaws.com/ci/o-halfpage.png')
+				.assert.attributeContains('img', 'src', 'https://tpc.googlesyndication.com/simgad/13534452929848566596')
 				// switch focus back to main page
 				.frame(null);
 	},
@@ -62,7 +62,7 @@ module.exports = {
 				// wait for 1 second for advert to appear
 				.waitForElementPresent('img', wait, 'Second adaptive advert image is visible')
 				// make sure we can see the correct URL
-				.assert.attributeContains('img', 'src', 'https://tpc.googlesyndication.com/simgad/6447322607352706781')
+				.assert.attributeContains('img', 'src', 'https://tpc.googlesyndication.com/simgad/11544125268120182564')
 				// switch focus back to main page
 				.frame(null);
 	},

--- a/test/qunit/slots.responsive.test.js
+++ b/test/qunit/slots.responsive.test.js
@@ -1,0 +1,174 @@
+/* globals QUnit: false, $: false */
+
+'use strict'; //eslint-disable-line
+
+QUnit.module('Responsive slots', {
+	beforeEach: function() {
+		window.scrollTo(0, 0);
+		this.server = this.server();
+		this.server.autoRespond = true;
+	},
+
+	afterEach: function() {
+		window.scrollTo(0, 0);
+	}
+});
+
+QUnit.test('create a slot with responsive sizes via sizes attributes', function(assert) {
+	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-sizes-large="300x600,300x1050"  data-o-ads-sizes-medium="300x400, 300x600"  data-o-ads-sizes-small="false"></div>';
+	const expected = { small:false, medium:[[300, 400], [300, 600]], large:[[300, 600], [300, 1050]]};
+	const node = this.fixturesContainer.add(slotHTML);
+	this.ads.init({
+		responsive: {
+			small: [0, 0],
+			medium: [400, 400],
+			large: [600, 600]
+		}
+	});
+	this.ads.slots.initSlot(node);
+	const result = this.ads.slots.mpu;
+	assert.deepEqual(result.sizes, expected, 'sizes are parsed into slot config.');
+});
+
+QUnit.test('create a slot with responsive sizes via formats attributes', function(assert) {
+	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-formats-large="Leaderboard"  data-o-ads-formats-medium="MediumRectangle"  data-o-ads-formats-small="false"></div>';
+	const expected = { small:false, medium:[[300, 250]], large:[[728, 90]]};
+	const node = this.fixturesContainer.add(slotHTML);
+	this.ads.init({
+		responsive: {
+			small: [0, 0],
+			medium: [400, 400],
+			large: [600, 600]
+		}
+	});
+	this.ads.slots.initSlot(node);
+	const result = this.ads.slots.mpu;
+	assert.deepEqual(result.sizes, expected, 'Formats names are parsed and the matching sizes are pulled from config.');
+});
+
+QUnit.test('responsive slot should refresh when a new size exists for a breakpoint', function(assert) {
+	const clock = this.date();
+	this.viewport(700, 700);
+
+
+	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-formats-large="SuperLeaderboard"  data-o-ads-formats-medium="MediumRectangle"  data-o-ads-formats-small="Billboard"></div>';
+	const node = this.fixturesContainer.add(slotHTML);
+	this.ads.init({
+		responsive: {
+			small: [0, 0],
+			medium: [400, 400],
+			large: [600, 600]
+		}
+	});
+
+	this.ads.slots.initSlot(node);
+	const slot = this.ads.slots.mpu;
+	assert.ok(this.gpt.display.calledOnce, 'Initial ad call is made for large size.');
+	let iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
+	assert.deepEqual(iframeSize, ['970', '90'], 'The ad slot is displayed at the correct size.');
+	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'SuperLeaderboard');
+	assert.equal(this.ads.targeting.get().res, 'large');
+	this.viewport(500, 500);
+	window.dispatchEvent(new Event('resize'));
+	clock.tick(300);
+	assert.ok(this.gpt.pubads().refresh.calledOnce, 'When screen size is changed, ad call is made.');
+	iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
+	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'MediumRectangle');
+	assert.equal(this.ads.targeting.get().res, 'medium');
+	assert.deepEqual(iframeSize, ['300', '250'], 'The new size is displayed.');
+	this.viewport(200,200);
+	window.dispatchEvent(new Event('resize'));
+	clock.tick(300);
+	assert.equal(this.ads.targeting.get().res, 'small');
+	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'false');
+});
+
+QUnit.test('responsive slot should not make a call when size is false', function(assert) {
+	const clock = this.date();
+	this.viewport(200, 200);
+
+	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-formats-large="Leaderboard"  data-o-ads-formats-medium="MediumRectangle"  data-o-ads-formats-small="false"></div>';
+	const node = this.fixturesContainer.add(slotHTML);
+	this.ads.init({
+		responsive: {
+			small: [0, 0],
+			medium: [400, 400],
+			large: [600, 600]
+		}
+	});
+	this.ads.slots.initSlot(node);
+	const slot = this.ads.slots.mpu;
+	assert.ok(!this.gpt.display.called, 'When size is false no ad call is made.');
+	assert.ok($(slot.container).hasClass('o-ads--empty'), 'The ad slot is not displayed.');
+
+	this.viewport(500, 500);
+	window.dispatchEvent(new Event('resize'));
+	clock.tick(300);
+	assert.ok(this.gpt.display.calledOnce, 'When screen size is changed, ad call is made.');
+	assert.notOk($(slot.container).hasClass('o-ads--empty'), 'The ad slot is displayed.');
+
+	this.viewport(700, 700);
+	window.dispatchEvent(new Event('resize'));
+	clock.tick(300);
+	assert.ok(this.gpt.pubads().refresh.calledOnce, 'When screen size is changed to large, ad call is made.');
+	assert.notOk($(slot.container).hasClass('o-ads--empty'), 'The ad slot is displayed.');
+
+	this.viewport(200, 200);
+	window.dispatchEvent(new Event('resize'));
+	clock.tick(300);
+	assert.ok(this.gpt.display.calledOnce, 'When screen size is change to, no ad call is made.');
+	assert.ok($(slot.container).hasClass('o-ads--empty'), 'The ad slot is not displayed.');
+});
+
+
+
+QUnit.test('Responsive format type (for responsive creatives) should not refresh even when loaded in a responsive configured slot', function(assert) {
+	const clock = this.date();
+
+	this.viewport(700, 700);
+	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-formats-large="Responsive"  data-o-ads-formats-medium="Responsive"  data-o-ads-formats-small="false"></div>';
+	const node = this.fixturesContainer.add(slotHTML);
+	this.ads.init({
+		responsive: {
+			small: [0, 0],
+			medium: [400, 400],
+			large: [600, 600]
+		}
+	});
+	this.ads.slots.initSlot(node);
+	const slot = this.ads.slots.mpu;
+	assert.ok(this.gpt.display.calledOnce, 'Initial ad call is made.');
+
+	//Initial ad load shows responsive ad
+	let iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
+	assert.deepEqual(iframeSize, ['2', '2'], 'The ad slot is displayed at the correct size.');
+	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'Responsive');
+	assert.equal(this.ads.targeting.get().res, 'large');
+
+	//Resizing to medium should not make an additional call, since it is still requesting a Responsive format
+	this.viewport(500, 500);
+	window.dispatchEvent(new Event('resize'));
+	clock.tick(300);
+	assert.equal(this.gpt.pubads().refresh.callCount, 0, 'When screen size is changed no ad call is made made for Responsive format');
+	iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
+	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'Responsive');
+	assert.equal(this.ads.targeting.get().res, 'medium');
+	assert.deepEqual(iframeSize, ['2', '2'], 'The iframe size is unchanged.');
+	assert.notOk($(slot.container).hasClass('o-ads--empty'), 'The ad slot is displayed.');
+
+	//Resizing to small should collapse the ad
+	this.viewport(200,200);
+	window.dispatchEvent(new Event('resize'));
+	clock.tick(300);
+	assert.equal(this.gpt.pubads().refresh.callCount, 0, 'When screen size is changed to small (set to false) it removes the ad');
+	assert.equal(this.ads.targeting.get().res, 'small');
+	assert.ok($(slot.container).hasClass('o-ads--empty'), 'The ad slot is not displayed.');
+
+	//Resizing back up to large should show the ad again
+	this.viewport(700,700);
+	window.dispatchEvent(new Event('resize'));
+	clock.tick(300);
+	assert.equal(this.ads.targeting.get().res, 'large');
+	assert.notOk($(slot.container).hasClass('o-ads--empty'), 'The ad slot is displayed.');
+
+});

--- a/test/qunit/slots.test.js
+++ b/test/qunit/slots.test.js
@@ -146,22 +146,6 @@ QUnit.test('create a slot with an invalid size among multiple sizes', function(a
 	assert.deepEqual(result.sizes, expected, 'Invalid size is ignored');
 });
 
-QUnit.test('create a slot with responsive sizes via sizes attributes', function(assert) {
-	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-sizes-large="300x600,300x1050"  data-o-ads-sizes-medium="300x400, 300x600"  data-o-ads-sizes-small="false"></div>';
-	const expected = { small:false, medium:[[300, 400], [300, 600]], large:[[300, 600], [300, 1050]]};
-	const node = this.fixturesContainer.add(slotHTML);
-	this.ads.init({
-		responsive: {
-			small: [0, 0],
-			medium: [400, 400],
-			large: [600, 600]
-		}
-	});
-	this.ads.slots.initSlot(node);
-	const result = this.ads.slots.mpu;
-	assert.deepEqual(result.sizes, expected, 'sizes are parsed into slot config.');
-});
-
 QUnit.test('create a slot with sizes via format attribute', function(assert) {
 	const expected = [[300, 250]];
 	const node = this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
@@ -175,134 +159,6 @@ QUnit.test('create a slot with sizes via format attribute', function(assert) {
 	this.ads.slots.initSlot(node);
 	const result = this.ads.slots.mpu;
 	assert.deepEqual(result.sizes, expected, 'Formats names are parsed and the matching sizes are pulled from config.');
-});
-
-QUnit.test('create a slot with responsive sizes via formats attributes', function(assert) {
-	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-formats-large="Leaderboard"  data-o-ads-formats-medium="MediumRectangle"  data-o-ads-formats-small="false"></div>';
-	const expected = { small:false, medium:[[300, 250]], large:[[728, 90]]};
-	const node = this.fixturesContainer.add(slotHTML);
-	this.ads.init({
-		responsive: {
-			small: [0, 0],
-			medium: [400, 400],
-			large: [600, 600]
-		}
-	});
-	this.ads.slots.initSlot(node);
-	const result = this.ads.slots.mpu;
-	assert.deepEqual(result.sizes, expected, 'Formats names are parsed and the matching sizes are pulled from config.');
-});
-
-QUnit.test('responsive slot should refresh when a new size exists for a breakpoint', function(assert) {
-	const clock = this.date();
-	this.viewport(700, 700);
-
-
-	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-formats-large="SuperLeaderboard"  data-o-ads-formats-medium="MediumRectangle"  data-o-ads-formats-small="Billboard"></div>';
-	const node = this.fixturesContainer.add(slotHTML);
-	this.ads.init({
-		responsive: {
-			small: [0, 0],
-			medium: [400, 400],
-			large: [600, 600]
-		}
-	});
-
-	this.ads.slots.initSlot(node);
-	const slot = this.ads.slots.mpu;
-	assert.ok(this.gpt.display.calledOnce, 'Initial ad call is made for large size.');
-	let iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
-	assert.deepEqual(iframeSize, ['970', '90'], 'The ad slot is displayed at the correct size.');
-	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'SuperLeaderboard');
-	assert.equal(this.ads.targeting.get().res, 'large');
-	this.viewport(500, 500);
-	window.dispatchEvent(new Event('resize'));
-	clock.tick(300);
-	assert.ok(this.gpt.pubads().refresh.calledOnce, 'When screen size is changed, ad call is made.');
-	iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
-	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'MediumRectangle');
-	assert.equal(this.ads.targeting.get().res, 'medium');
-	assert.deepEqual(iframeSize, ['300', '250'], 'The new size is displayed.');
-	this.viewport(200,200);
-	window.dispatchEvent(new Event('resize'));
-	clock.tick(300);
-	assert.equal(this.ads.targeting.get().res, 'small');
-	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'false');
-});
-
-QUnit.test('responsive slot should not make a call when size is false', function(assert) {
-	const clock = this.date();
-	this.viewport(200, 200);
-
-	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-formats-large="Leaderboard"  data-o-ads-formats-medium="MediumRectangle"  data-o-ads-formats-small="false"></div>';
-	const node = this.fixturesContainer.add(slotHTML);
-	this.ads.init({
-		responsive: {
-			small: [0, 0],
-			medium: [400, 400],
-			large: [600, 600]
-		}
-	});
-	this.ads.slots.initSlot(node);
-	const slot = this.ads.slots.mpu;
-	assert.ok(!this.gpt.display.called, 'When size is false no ad call is made.');
-	assert.ok($(slot.container).hasClass('o-ads--empty'), 'The ad slot is not displayed.');
-
-	this.viewport(500, 500);
-	window.dispatchEvent(new Event('resize'));
-	clock.tick(300);
-	assert.ok(this.gpt.display.calledOnce, 'When screen size is changed, ad call is made.');
-	assert.notOk($(slot.container).hasClass('o-ads--empty'), 'The ad slot is displayed.');
-
-	this.viewport(700, 700);
-	window.dispatchEvent(new Event('resize'));
-	clock.tick(300);
-	assert.ok(this.gpt.pubads().refresh.calledOnce, 'When screen size is changed to large, ad call is made.');
-	assert.notOk($(slot.container).hasClass('o-ads--empty'), 'The ad slot is displayed.');
-
-	this.viewport(200, 200);
-	window.dispatchEvent(new Event('resize'));
-	clock.tick(300);
-	assert.ok(this.gpt.display.calledOnce, 'When screen size is change to, no ad call is made.');
-	assert.ok($(slot.container).hasClass('o-ads--empty'), 'The ad slot is not displayed.');
-});
-
-
-
-QUnit.test('Responsive format type (for responsive creatives) should not refresh even when loaded in a responsive configured slot', function(assert) {
-	const clock = this.date();
-	this.viewport(700, 700);
-	const slotHTML = '<div data-o-ads-name="mpu" data-o-ads-formats-large="Responsive"  data-o-ads-formats-medium="Responsive"  data-o-ads-formats-small="false"></div>';
-	const node = this.fixturesContainer.add(slotHTML);
-	this.ads.init({
-		responsive: {
-			small: [0, 0],
-			medium: [400, 400],
-			large: [600, 600]
-		}
-	});
-	this.ads.slots.initSlot(node);
-	const slot = this.ads.slots.mpu;
-	assert.ok(this.gpt.display.calledOnce, 'Initial ad call is made.');
-	let iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
-	assert.deepEqual(iframeSize, ['2', '2'], 'The ad slot is displayed at the correct size.');
-	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'Responsive');
-	assert.equal(this.ads.targeting.get().res, 'large');
-	this.viewport(500, 500);
-	window.dispatchEvent(new Event('resize'));
-	clock.tick(300);
-	assert.equal(this.gpt.pubads().refresh.callCount, 0, 'When screen size is changed no ad call is made made for Responsive format');
-	iframeSize = [slot.gpt.iframe.width, slot.gpt.iframe.height];
-	assert.equal(slot.container.getAttribute('data-o-ads-loaded'), 'Responsive');
-	assert.equal(this.ads.targeting.get().res, 'medium');
-	assert.deepEqual(iframeSize, ['2', '2'], 'The iframe size is unchanged.');
-	assert.notOk($(slot.container).hasClass('o-ads--empty'), 'The ad slot is displayed.');
-	this.viewport(200,200);
-	window.dispatchEvent(new Event('resize'));
-	clock.tick(300);
-	assert.equal(this.gpt.pubads().refresh.callCount, 0, 'When screen size is changed to small (set to false) it removes the ad');
-	assert.equal(this.ads.targeting.get().res, 'small');
-	assert.ok($(slot.container).hasClass('o-ads--empty'), 'The ad slot is not displayed.');
 });
 
 QUnit.test('Center container', function(assert) {
@@ -414,6 +270,7 @@ QUnit.test('Slots.collapse will collapse a single slot', function(assert) {
 	this.ads.slots.initSlot(node);
 	this.ads.slots.collapse('collapse-test');
 	assert.ok($(node).hasClass('o-ads--empty'), 'slot is collapsed');
+	assert.equal(this.fixturesContainer.getAttribute('data-o-ads-loaded', false));
 });
 
 QUnit.test('Slots.collapse will collapse mulitple slots', function(assert) {


### PR DESCRIPTION
/cc @VladDubrovskis @andrewgeorgiou1981  
Hopefully fixes most of the resizing issues, by making the logic a little clearer and more precise.

Note: moved responsive tests out into their own file as slots.test.js was getting huge.