### PR TITLE
Improve initialisation logic with multiple DOMContentLoaded calls

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 function Ads() {
+	addDOMEventListener();
 }
 
 // bung all our modules on the protoype
@@ -25,6 +26,9 @@ Ads.prototype.init = function(config) {
 	this.rubicon.init();
 	this.admantx.init();
 	this.utils.on('debug', this.debug.bind(this));
+
+	removeDOMEventListener();
+
 	return this;
 };
 
@@ -40,8 +44,6 @@ const initAll = function() {
 		const slots = Array.from(document.querySelectorAll('.o-ads, [data-o-ads-name]'));
 		slots.forEach(ads.slots.initSlot.bind(ads.slots));
 	}
-
-	document.documentElement.removeEventListener('o.DOMContentLoaded', initAll);
 };
 
 Ads.prototype.debug = function (){
@@ -62,6 +64,11 @@ Ads.prototype.debug = function (){
 	}
 };
 
+function addDOMEventListener() {
 document.addEventListener('o.DOMContentLoaded', initAll);
+}
+function removeDOMEventListener() {
+	document.removeEventListener('o.DOMContentLoaded', initAll);
+}
 
 module.exports = ads;

--- a/main.js
+++ b/main.js
@@ -32,7 +32,6 @@ Ads.prototype.init = function(config) {
 	return this;
 };
 
-const ads = new Ads();
 const initAll = function() {
 	const metas = Array.from(document.getElementsByTagName('meta'));
 	const stop = metas.filter(function(meta) {
@@ -65,10 +64,11 @@ Ads.prototype.debug = function (){
 };
 
 function addDOMEventListener() {
-document.addEventListener('o.DOMContentLoaded', initAll);
+	document.addEventListener('o.DOMContentLoaded', initAll);
 }
 function removeDOMEventListener() {
 	document.removeEventListener('o.DOMContentLoaded', initAll);
 }
 
+const ads = new Ads();
 module.exports = ads;

--- a/test/qunit/main.test.js
+++ b/test/qunit/main.test.js
@@ -20,12 +20,30 @@ QUnit.test('init all only is triggered once', function(assert) {
 	const ads = new this.adsConstructor();
 	const gptInit = this.spy(ads.gpt, 'init');
 
+	assert.equal(gptInit.callCount, 0, 'gpt init function is not called on construction');
+
 	this.trigger(document, 'o.DOMContentLoaded');
 	assert.ok(gptInit.calledOnce, 'gpt init function is called once via initAll');
 
 	this.trigger(document, 'o.DOMContentLoaded');
 	assert.ok(gptInit.calledOnce, 'gpt init function is called exactly once via multiple initAll calls');
-})
+});
+
+QUnit.test('manual inits always trigger but DOM inits do not override', function (assert) {
+	const ads = new this.adsConstructor();
+	const gptInit = this.spy(ads.gpt, 'init');
+
+	assert.equal(gptInit.callCount, 0, 'gpt init function is not called on construction');
+
+	ads.init();
+	assert.ok(gptInit.calledOnce, 'gpt init function is called once via manual init');
+
+	this.trigger(document, 'o.DOMContentLoaded');
+	assert.ok(gptInit.calledOnce, 'gpt init function is called exactly once despite subsequent DOMContentLoaded event');
+
+	ads.init();
+	assert.ok(gptInit.calledTwice, 'manual init call does re-initialise');
+});
 
 QUnit.test("debug calls modules' debug functions", function(assert) {
 	const admantxDebug = this.spy(this.ads.admantx, 'debug');

--- a/test/qunit/main.test.js
+++ b/test/qunit/main.test.js
@@ -14,8 +14,18 @@ QUnit.test('init All', function(assert) {
 		done();
 	});
 	this.trigger(document, 'o.DOMContentLoaded');
-
 });
+
+QUnit.test('init all only is triggered once', function(assert) {
+	const ads = new this.adsConstructor();
+	const gptInit = this.spy(ads.gpt, 'init');
+
+	this.trigger(document, 'o.DOMContentLoaded');
+	assert.ok(gptInit.calledOnce, 'gpt init function is called once via initAll');
+
+	this.trigger(document, 'o.DOMContentLoaded');
+	assert.ok(gptInit.calledOnce, 'gpt init function is called exactly once via multiple initAll calls');
+})
 
 QUnit.test("debug calls modules' debug functions", function(assert) {
 	const admantxDebug = this.spy(this.ads.admantx, 'debug');

--- a/test/qunit/setup.js
+++ b/test/qunit/setup.js
@@ -48,6 +48,7 @@ function decorateModule() {
 		return {
 			beforeEach: function() {
 				let mod;
+				this.adsConstructor = Ads;
 				this.ads = new Ads();
 				this.utils = utils;
 				window.scroll(0, 0);


### PR DESCRIPTION
Started looking at this code due to a problem where o-autoinit as part of a lazy-loaded comments setup was calling DOMContentLoaded again; this caused the already-initialised o-ads instance to reinitialise itself and wipe out any existing config.

Looking at the existing logic, the previous DOMContentLoaded event listener was added to document but removed from document.documentElement, so it could get triggered multiple times. Fixing that caused test failures because of some magic global state in the test runs, so I've also moved the event handling setup to within the constructor, and moved teardown to part of init; this ensures that in normal usage, init() will only be called once unless there are multiple explicit external calls.