### PR TITLE
ADS-963: companion slots which are configured as 'false' f or a given screensize should never render at that screensize even when lazy-loading of the slot is enabled

### DIFF
--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -232,11 +232,14 @@ Slot.prototype.initLazyLoad = function() {
 }
 
 Slot.prototype.render = function() {
-	this.fire('render');
-	if(this.lazyLoadObserver) {
-		this.lazyLoadObserver.unobserve(this.container);
+	if (this.hasValidSize()){
+		this.fire('render');
+		if(this.lazyLoadObserver) {
+			this.lazyLoadObserver.unobserve(this.container);
+		}
 	}
 };
+
 
 /**
  *	Listen to responsive breakpoints and collapse slots

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -224,7 +224,9 @@ Slot.prototype.initLazyLoad = function() {
 		/* istanbul ignore else */
 		if(this.companion) {
 			utils.once('masterLoaded', () => {
-				this.render();
+				if (this.hasValidSize()){
+					this.render();
+				}
 			}, this.container);
 		}
 	}
@@ -232,11 +234,9 @@ Slot.prototype.initLazyLoad = function() {
 }
 
 Slot.prototype.render = function() {
-	if (this.hasValidSize()){
-		this.fire('render');
-		if(this.lazyLoadObserver) {
-			this.lazyLoadObserver.unobserve(this.container);
-		}
+	this.fire('render');
+	if(this.lazyLoadObserver) {
+		this.lazyLoadObserver.unobserve(this.container);
 	}
 };
 

--- a/test/qunit/slots.test.js
+++ b/test/qunit/slots.test.js
@@ -886,6 +886,15 @@ QUnit.test('lazy loading a companion slot', function(assert) {
 	this.utils.broadcast('masterLoaded', {}, node);
 });
 
+QUnit.test('companion slots which are configured as false for a specific screensize should not render at that screensize', function(assert) {
+	const slotHTML = '<div data-o-ads-name="lazy-companion-test" data-o-ads-lazy-load="true" data-o-ads-formats-default="false" data-o-ads-formats-large="false" data-o-ads-formats-small="false" data-o-ads-formats-medium="false" data-o-ads-formats-extra="false" style="position: absolute; left: -1000px; top: -1000px"></div>';
+	const node = this.fixturesContainer.add(slotHTML);
+	this.ads.init();
+	const slot = this.ads.slots.initSlot(node);
+	const renderSpy = this.spy(slot, 'render');
+	this.utils.broadcast('masterLoaded', {}, node);
+	assert.notOk(renderSpy.calledOnce, 'slot fire method is not called');
+});
 
 QUnit.test('lazy loading loads the ad normal way if IntersectionObserver is not available', function(assert) {
 	const originalObserver = window.IntersectionObserver;

--- a/test/qunit/slots.test.js
+++ b/test/qunit/slots.test.js
@@ -894,6 +894,7 @@ QUnit.test('companion slots which are configured as false for a specific screens
 	const renderSpy = this.spy(slot, 'render');
 	this.utils.broadcast('masterLoaded', {}, node);
 	assert.notOk(renderSpy.calledOnce, 'slot fire method is not called');
+	renderSpy.restore();
 });
 
 QUnit.test('lazy loading loads the ad normal way if IntersectionObserver is not available', function(assert) {


### PR DESCRIPTION
@adgad @VladDubrovskis 