### PR TITLE
Update Krux URL to newer one

### DIFF
--- a/src/js/data-providers/krux.js
+++ b/src/js/data-providers/krux.js
@@ -37,7 +37,7 @@ Krux.prototype.init = function() {
 		if (m) {
 			src = decodeURIComponent(m[1]);
 		}
-		const finalSrc = /^https?:\/\/([^\/]+\.)?krxd\.net(:\d{1,5})?\//i.test(src) ? src : src === "disable" ? "" : `//cdn.krxd.net/controltag?confid=${this.config.id}`;
+		const finalSrc = /^https?:\/\/([^\/]+\.)?krxd\.net(:\d{1,5})?\//i.test(src) ? src : src === "disable" ? "" : `//cdn.krxd.net/controltag/${this.config.id}.js`;
 		
 		const loadKruxScript = () => {
 			utils.attach(finalSrc, true, () => {


### PR DESCRIPTION
Krux does some weird thing where it downloads all it's URLs twice. Most of these are the same file so will be cache hits - but the controltag URL it downloads the second time is the newer one.

This updates the URL we use to the newer one, so that the second hit is a cache hit.