### PR TITLE
Remove referrer targeting k/v

### DIFF
--- a/src/js/targeting.js
+++ b/src/js/targeting.js
@@ -9,7 +9,6 @@ function Targeting() {
 Targeting.prototype.get = function() {
 	const methods = {
 		socialReferrer: this.getSocialReferrer,
-		pageReferrer: this.getPageReferrer,
 		timestamp: this.timestamp,
 		responsive: this.responsive
 	};
@@ -51,26 +50,6 @@ Targeting.prototype.getFromConfig = function() {
 	}
 
 	return targeting;
-};
-
-Targeting.prototype.getPageReferrer = function() {
-	let hostRegex;
-	let match = null;
-	const referrer = utils.getReferrer();
-
-	//referrer is not article
-	if (referrer !== '') {
-		hostRegex = /^.*?:\/\/.*?(\/.*)$/;
-
-		//remove hostname from results
-		match = hostRegex.exec(referrer)[1];
-		/* istanbul ignore else  */
-		if (match !== null) {
-			match.substring(1);
-		}
-	}
-
-	return match && {rf: match.substring(1)} || {};
 };
 
 Targeting.prototype.getSocialReferrer = function() {

--- a/test/qunit/targeting.test.js
+++ b/test/qunit/targeting.test.js
@@ -8,13 +8,11 @@ QUnit.module('Targeting', {
 QUnit.test('getFromConfig', function(assert) {
 	this.ads.init({});
 	let result = this.ads.targeting.get();
-	delete result.rf; //Qunit sometimes has referrer
 	assert.ok(result.ts, 'timestamp exists');
 	assert.ok(result.res, 'responsive breakpoint exists');
 	this.ads.targeting.clear();
 	this.ads.config('dfp_targeting', '');
 	result = this.ads.targeting.get();
-	delete result.rf; //Qunit sometimes has referrer
 	assert.deepEqual(Object.keys(result).length, 2, 'Empty string dfp_targeting returns only default params');
 
 
@@ -87,21 +85,6 @@ QUnit.test("social referrer", function(assert) {
 	this.ads.init({ socialReferrer: true });
 	result = this.ads.targeting.get();
 	assert.equal(result.socref, "dru", "Via login, drudge should be mapped from drudgereport.com to dru");
-});
-
-QUnit.test('Page referrer', function(assert) {
-	let result;
-	const referrer = this.stub(this.ads.utils, 'getReferrer');
-
-	referrer.returns('');
-	this.ads.init({ pageReferrer: true });
-	result = this.ads.targeting.get();
-	assert.equal(result.rf, undefined, "calling rf returns undefined");
-
-	referrer.returns('http://www.example.com/some/page?some=param');
-	this.ads.init({ pageReferrer: true });
-	result = this.ads.targeting.get();
-	assert.equal(result.rf, 'some/page?some=param', "referrer is returned without domain");
 });
 
 QUnit.test("search term", function(assert) {


### PR DESCRIPTION
@VladDubrovskis @andrewgeorgiou1981 @gvonkoss 
Some site's referers have their PII data in query strings, so don't send it (we still send socref, which seems like it's why they needed referers in the first place - and it's also sent _somewhere_ in the GPT call.