### PR TITLE
hide ads from screen readers

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -242,6 +242,9 @@ function onRenderEnded(event) {
 	detail.lineItemId = event.lineItemId;
 	detail.serviceName = event.serviceName;
 	detail.iframe = document.getElementById(iframeId);
+	detail.iframe.setAttribute('tabindex', '-1');
+	detail.iframe.setAttribute('aria-hidden', 'true');
+	detail.iframe.setAttribute('role', 'presentation');
 	utils.broadcast('rendered', data);
 }
 


### PR DESCRIPTION
Setting these attributes on the o-ads container was not enough, they need to be on the iframe for screen readers and other assistive tech to really skip them

Would this catch all ads on the site, though?

@adgad @GlynnPhillips 