### PR TITLE
Add title to ad iFrame

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -245,6 +245,7 @@ function onRenderEnded(event) {
 	detail.iframe.setAttribute('tabindex', '-1');
 	detail.iframe.setAttribute('aria-hidden', 'true');
 	detail.iframe.setAttribute('role', 'presentation');
+	detail.iframe.setAttribute('title', 'Advertisement');
 	utils.broadcast('rendered', data);
 }
 


### PR DESCRIPTION
Gets rid of our last remaining `pa11y` error http://a11y.ft.com/58468e2d585a081100d9051a

<img width="704" alt="screen shot 2017-01-14 at 19 55 10" src="https://cloud.githubusercontent.com/assets/3425322/21957661/6631312c-da93-11e6-937e-776edb2c34e8.png">

Ads are hidden from screen readers, so afaik this won't be read out to any end users. It's more for strict compliance with WCAG2.0, follows their recommendation in https://www.w3.org/TR/WCAG20-TECHS/H64.html, and ensures anyone who wants to run an audit of our site will see a nice, clean `0 Errors`.