### PR TITLE
Changes required to implement page level targeting on webapp

### DIFF
--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -16,11 +16,12 @@ Api.prototype.getUserData = function(target) {
 
 }
 
-Api.prototype.getPageData = function(target) {
+Api.prototype.getPageData = function(target, timeout) {
 	if(!target) { return Promise.resolve({}) };
 
+	timeout = timeout || 2000;
 	return fetch(target, {
-		timeout: 2000,
+		timeout: timeout,
 		useCorsProxy: true
 	})
 	.then( res => res.json())

--- a/src/js/data-providers/krux.js
+++ b/src/js/data-providers/krux.js
@@ -212,20 +212,20 @@ Krux.prototype.setAllAttributes = function() {
 }
 
 Krux.prototype.resetAttributes = function(attributes) {
-	allAttributes = ['user', 'page', 'custom'];
+	const allAttributes = ['user', 'page', 'custom'];
 	attributes = Array.isArray(attributes) ? attributes : [attributes];
 	attributes = attributes
 		? attributes.map(attr => allAttributes.indexOf(attr) > -1)
 		: allAttributes;
-	['user', 'page', 'custom'].forEach(type => {
+	attributes.forEach(type => {
 		if(this.customAttributes[type]) {
 			Object.keys(this.customAttributes[type]).forEach(key => {
 				window.Krux('set', type === 'custom' ? key : `${type}_attr_${key}`, null);
 			});
+			delete this.customAttributes[type];
 		}
 	});
 
-	this.customAttributes = {};
 }
 
 Krux.prototype.debug = function() {

--- a/src/js/data-providers/krux.js
+++ b/src/js/data-providers/krux.js
@@ -81,7 +81,7 @@ Krux.prototype.init = function() {
 /**
 * retrieve Krux values from localstorage or cookies in older browsers.
 * @name retrieve
-* @memberof Krux 
+* @memberof Krux
 * @lends Krux
 */
 Krux.prototype.retrieve = function(name) {
@@ -179,7 +179,7 @@ Krux.prototype.events.fire = function(id, attrs) {
 
 Krux.prototype.events.init = function() {
 	let event;
-    const configured = config('krux') && config('krux').events;
+	const configured = config('krux') && config('krux').events;
 	/* istanbul ignore else  */
 	if (utils.isPlainObject(configured)) {
 		for (event in configured) {
@@ -211,7 +211,12 @@ Krux.prototype.setAllAttributes = function() {
 	}
 }
 
-Krux.prototype.resetAttributes = function() {
+Krux.prototype.resetAttributes = function(attributes) {
+	allAttributes = ['user', 'page', 'custom'];
+	attributes = Array.isArray(attributes) ? attributes : [attributes];
+	attributes = attributes
+		? attributes.map(attr => allAttributes.indexOf(attr) > -1)
+		: allAttributes;
 	['user', 'page', 'custom'].forEach(type => {
 		if(this.customAttributes[type]) {
 			Object.keys(this.customAttributes[type]).forEach(key => {

--- a/src/js/data-providers/krux.js
+++ b/src/js/data-providers/krux.js
@@ -211,21 +211,25 @@ Krux.prototype.setAllAttributes = function() {
 	}
 }
 
-Krux.prototype.resetAttributes = function(attributes) {
-	const allAttributes = ['user', 'page', 'custom'];
-	attributes = Array.isArray(attributes) ? attributes : [attributes];
-	attributes = attributes
-		? attributes.map(attr => allAttributes.indexOf(attr) > -1)
-		: allAttributes;
-	attributes.forEach(type => {
+Krux.prototype.resetAttributes = function() {
+	['user', 'page', 'custom'].forEach(type => {
 		if(this.customAttributes[type]) {
 			Object.keys(this.customAttributes[type]).forEach(key => {
 				window.Krux('set', type === 'custom' ? key : `${type}_attr_${key}`, null);
 			});
-			delete this.customAttributes[type];
 		}
 	});
 
+	this.customAttributes = {};
+}
+
+Krux.prototype.resetSpecificAttribute = function(type) {
+	if(this.customAttributes[type]) {
+		Object.keys(this.customAttributes[type]).forEach(key => {
+			window.Krux('set', type === 'custom' ? key : `${type}_attr_${key}`, null);
+		});
+		delete this.customAttributes[type];
+	}
 }
 
 Krux.prototype.debug = function() {

--- a/test/qunit/api.test.js
+++ b/test/qunit/api.test.js
@@ -198,7 +198,7 @@ QUnit.test("makes use of custom set timeout when calling getPageData directly", 
   const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.content);
 
-  const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/content/16502d40-3559-11e7-99bd-13beb0903fa3');
+  const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/content/16502d40-3559-11e7-99bd-13beb0903fa3', pageJSON);
 
   const ads = this.ads.api.getPageData('16502d40-3559-11e7-99bd-13beb0903fa3', 300);
 

--- a/test/qunit/api.test.js
+++ b/test/qunit/api.test.js
@@ -7,7 +7,7 @@ const fetchMock = require('fetch-mock');
 QUnit.module('ads API config', {});
 
 QUnit.test('resolves with an empty promise if called without any urls', function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 
 	this.ads.api.init()
 	.then(res => {
@@ -17,16 +17,16 @@ QUnit.test('resolves with an empty promise if called without any urls', function
 
 });
 QUnit.test('can handle errors in the api response', function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 
-  fetchMock.get('https://ads-api.ft.com/v1/concept/error', 500)
-  fetchMock.get('https://ads-api.ft.com/v1/user/error', 500)
+	fetchMock.get('https://ads-api.ft.com/v1/concept/error', 500)
+	fetchMock.get('https://ads-api.ft.com/v1/user/error', 500)
 
-  const ads = this.ads.init({
+	const ads = this.ads.init({
 		targetingApi: {
 			page: 'https://ads-api.ft.com/v1/concept/error',
 			user: 'https://ads-api.ft.com/v1/user/error'
-    },
+		},
 		gpt: {
 			network: '5887',
 			site: 'ft.com',
@@ -35,130 +35,130 @@ QUnit.test('can handle errors in the api response', function(assert) {
 	});
 
 
-  ads.then((ads) => {
-    const targeting = ads.targeting.get();
-    const config = ads.config();
+	ads.then((ads) => {
+		const targeting = ads.targeting.get();
+		const config = ads.config();
 
 		assert.equal(ads.isInitialised, true);
 		assert.equal(config.gpt.zone, 'unclassified');
-  	done();
+		done();
 	});
 
 });
 
 
 QUnit.test("makes api call to correct user url and adds correct data to targeting", function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const userJSON = JSON.stringify(this.fixtures.user);
 
-  const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/user', userJSON)
+	const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/user', userJSON)
 
-  let ads = this.ads.init({
+	let ads = this.ads.init({
 		targetingApi: {
 			user: 'https://ads-api.ft.com/v1/user',
-    },
-    krux: {
-      id: '1234'
-    }
+		},
+		krux: {
+			id: '1234'
+		}
 	});
 
-  ads.then((ads) => {
-    const targeting = ads.targeting.get();
-    const config = ads.config();
-    const dfp_targeting =  {
-          "device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
-          "guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
-          "slv": "int",
-          "loggedIn": true,
-          "gender": "F"
-    };
-    const krux_targeting =  {
-            "user": {
-            "device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
-            "guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
-            "subscription_level": "int",
-            "loggedIn": true,
-            "gender": "F"
-          }
-    };
+	ads.then((ads) => {
+		const targeting = ads.targeting.get();
+		const config = ads.config();
+		const dfp_targeting =  {
+					"device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
+					"guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
+					"slv": "int",
+					"loggedIn": true,
+					"gender": "F"
+		};
+		const krux_targeting =  {
+						"user": {
+						"device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
+						"guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
+						"subscription_level": "int",
+						"loggedIn": true,
+						"gender": "F"
+					}
+		};
 		const lastCallOpts = apiCallMock.lastCall()[1];
 		assert.equal(lastCallOpts.credentials, "include");
 		assert.equal(lastCallOpts.timeout, 2000);
 		assert.equal(lastCallOpts.useCorsProxy, true);
 
-    Object.keys(dfp_targeting).forEach((key) => {
-      assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
-    });
-    assert.deepEqual(ads.krux.customAttributes.user, krux_targeting.user, 'the krux attributes are correct');
-    done();
-  });
+		Object.keys(dfp_targeting).forEach((key) => {
+			assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
+		});
+		assert.deepEqual(ads.krux.customAttributes.user, krux_targeting.user, 'the krux attributes are correct');
+		done();
+	});
 
 });
 
 QUnit.test("does not overwrite existing data in user config", function(assert) {
-  const done = assert.async();
-  const userJSON = JSON.stringify(this.fixtures.user);
+	const done = assert.async();
+	const userJSON = JSON.stringify(this.fixtures.user);
 
-  fetchMock.get('https://ads-api.ft.com/v1/user', userJSON)
+	fetchMock.get('https://ads-api.ft.com/v1/user', userJSON)
 
-  const ads = this.ads.init({
-    targetingApi: {
-      user: 'https://ads-api.ft.com/v1/user',
-    },
-    dfp_targeting: "custom_key=custom_value",
-    krux: {
-      id: '1234',
-      attributes: {
-        user: {
-          custom_key: 'custom value'
-        }
-      }
-    }
+	const ads = this.ads.init({
+		targetingApi: {
+			user: 'https://ads-api.ft.com/v1/user',
+		},
+		dfp_targeting: "custom_key=custom_value",
+		krux: {
+			id: '1234',
+			attributes: {
+				user: {
+					custom_key: 'custom value'
+				}
+			}
+		}
 	});
 
-  ads.then((ads) => {
+	ads.then((ads) => {
 		const targeting = ads.targeting.get();
-    const config = ads.config();
-    const dfp_targeting =  {
-          "custom_key": "custom_value",
-          "device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
-          "guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
-          "slv": "int",
-          "loggedIn": true,
-          "gender": "F"
-    };
-    const krux_targeting =  {
-          "custom_key": "custom value",
-          "device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
-          "guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
-          "subscription_level": "int",
-          "loggedIn": true,
-          "gender": "F"
-    };
+		const config = ads.config();
+		const dfp_targeting =  {
+					"custom_key": "custom_value",
+					"device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
+					"guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
+					"slv": "int",
+					"loggedIn": true,
+					"gender": "F"
+		};
+		const krux_targeting =  {
+					"custom_key": "custom value",
+					"device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
+					"guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
+					"subscription_level": "int",
+					"loggedIn": true,
+					"gender": "F"
+		};
 
-    Object.keys(dfp_targeting).forEach((key) => {
-        assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
-    });
+		Object.keys(dfp_targeting).forEach((key) => {
+				assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
+		});
 
-    assert.deepEqual(ads.krux.customAttributes.user, krux_targeting, 'the krux attributes are correct');
+		assert.deepEqual(ads.krux.customAttributes.user, krux_targeting, 'the krux attributes are correct');
 
-    done();
+		done();
 	});
 });
 
 QUnit.test("makes api call to correct page/content url and adds correct data to targeting", function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.content);
 
-  const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
+	const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
 
-  const ads = this.ads.init({
+	const ads = this.ads.init({
 		targetingApi: {
 			page: 'https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM='
-    },
-    krux: {
-      id: '1234'
-    }
+		},
+		krux: {
+			id: '1234'
+		}
 	});
 
 
@@ -167,115 +167,118 @@ QUnit.test("makes api call to correct page/content url and adds correct data to 
 	assert.equal(lastCallOpts.timeout, 2000);
 	assert.equal(lastCallOpts.useCorsProxy, true);
 
-  ads.then((ads) => {
-    const targeting = ads.targeting.get();
-    const config = ads.config();
-    const dfp_targeting =  {
-          "auuid": "13abbe62-70db-11e6-a0c9-1365ce54b926",
-          "ad": "ft11,s03,sm01,s05,s04,ft13",
-          "ca": "finance,company,business"
-    };
-    const krux_targeting =  {
-      "authors": ["Jung-a Song"],
-      "genre": ["News"],
-      "primarySection": ["Technology"],
-      "specialReports": [],
-      "topics": ["Mobile devices", "Batteries"]
-    };
+	ads.then((ads) => {
+		const targeting = ads.targeting.get();
+		const config = ads.config();
+		const dfp_targeting =  {
+					"auuid": "13abbe62-70db-11e6-a0c9-1365ce54b926",
+					"ad": "ft11,s03,sm01,s05,s04,ft13",
+					"ca": "finance,company,business"
+		};
+		const krux_targeting =  {
+			"authors": ["Jung-a Song"],
+			"genre": ["News"],
+			"primarySection": ["Technology"],
+			"specialReports": [],
+			"topics": ["Mobile devices", "Batteries"]
+		};
 
-    Object.keys(dfp_targeting).forEach((key) => {
-      assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
-    });
+		Object.keys(dfp_targeting).forEach((key) => {
+			assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
+		});
 
-    assert.deepEqual(ads.krux.customAttributes.page, krux_targeting, 'the krux attributes are correct');
-  	done();
+		assert.deepEqual(ads.krux.customAttributes.page, krux_targeting, 'the krux attributes are correct');
+		done();
 	});
 
 
 });
 
 QUnit.test("makes use of custom set timeout when calling getPageData directly", function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.content);
 
-  const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/content/16502d40-3559-11e7-99bd-13beb0903fa3', pageJSON);
+	const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/content/16502d40-3559-11e7-99bd-13beb0903fa3', pageJSON);
 
-  const ads = this.ads.api.getPageData('https://ads-api.ft.com/v1/content/16502d40-3559-11e7-99bd-13beb0903fa3', 300);
+	const ads = this.ads.api.getPageData('https://ads-api.ft.com/v1/content/16502d40-3559-11e7-99bd-13beb0903fa3', 300);
 
+	ads.then((ads) => {
+		const lastCallOpts = apiCallMock.lastCall()[1];
+		assert.equal(lastCallOpts.credentials, null);
+		assert.equal(lastCallOpts.timeout, 300);
+		assert.equal(lastCallOpts.useCorsProxy, true);
+		done();
+	});
 
-	const lastCallOpts = apiCallMock.lastCall()[1];
-	assert.equal(lastCallOpts.credentials, null);
-	assert.equal(lastCallOpts.timeout, 300);
-	assert.equal(lastCallOpts.useCorsProxy, true);
 
 });
 
 QUnit.test("does not overwrite existing data in page config", function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const userJSON = JSON.stringify(this.fixtures.user);
 	const pageJSON = JSON.stringify(this.fixtures.content);
 
-  fetchMock.get('https://ads-api.ft.com/v1/user', userJSON)
-  fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
+	fetchMock.get('https://ads-api.ft.com/v1/user', userJSON)
+	fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
 
-  const ads = this.ads.init({
+	const ads = this.ads.init({
 		targetingApi: {
 			user: 'https://ads-api.ft.com/v1/user',
 			page: 'https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM='
-    },
-    dfp_targeting: "custom_key=custom_value",
-    krux: {
-      id: '1234',
-      attributes: {
-        page: {
-          custom_key: 'custom_value'
-        }
-      }
-    },
+		},
+		dfp_targeting: "custom_key=custom_value",
+		krux: {
+			id: '1234',
+			attributes: {
+				page: {
+					custom_key: 'custom_value'
+				}
+			}
+		},
 		gpt: {
 
 		}
 	});
 
 
-  ads.then((ads) => {
-    const targeting = ads.targeting.get();
-    const config = ads.config();
-    const dfp_targeting =  {
-          "custom_key": "custom_value",
-          "auuid": "13abbe62-70db-11e6-a0c9-1365ce54b926",
-          "ad": "ft11,s03,sm01,s05,s04,ft13",
-          "ca": "finance,company,business"
-    };
-    const krux_targeting =  {
-      "custom_key": "custom_value",
-      "authors": ["Jung-a Song"],
-      "genre": ["News"],
-      "primarySection": ["Technology"],
-      "specialReports": [],
-      "topics": ["Mobile devices", "Batteries"]
-    };
+	ads.then((ads) => {
+		const targeting = ads.targeting.get();
+		const config = ads.config();
+		const dfp_targeting =  {
+					"custom_key": "custom_value",
+					"auuid": "13abbe62-70db-11e6-a0c9-1365ce54b926",
+					"ad": "ft11,s03,sm01,s05,s04,ft13",
+					"ca": "finance,company,business"
+		};
+		const krux_targeting =  {
+			"custom_key": "custom_value",
+			"authors": ["Jung-a Song"],
+			"genre": ["News"],
+			"primarySection": ["Technology"],
+			"specialReports": [],
+			"topics": ["Mobile devices", "Batteries"]
+		};
 
-    Object.keys(dfp_targeting).forEach((key) => {
-      assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
-    });
+		Object.keys(dfp_targeting).forEach((key) => {
+			assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
+		});
 
-    assert.deepEqual(ads.krux.customAttributes.page, krux_targeting, 'the krux attributes are correct');
-  	done();
+		assert.deepEqual(ads.krux.customAttributes.page, krux_targeting, 'the krux attributes are correct');
+		done();
 	});
 });
 
 QUnit.test('overwrites the config gpt zone with the adunit from the page response if "usePageZone" is true', function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.content);
 
-  fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
+	fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
 
-  const ads = this.ads.init({
+	const ads = this.ads.init({
 		targetingApi: {
 			page: 'https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=',
 			usePageZone: true
-    },
+		},
 		gpt: {
 			network: '5887',
 			site: 'ft.com',
@@ -284,26 +287,26 @@ QUnit.test('overwrites the config gpt zone with the adunit from the page respons
 	});
 
 
-  ads.then((ads) => {
-    const targeting = ads.targeting.get();
-    const config = ads.config();
+	ads.then((ads) => {
+		const targeting = ads.targeting.get();
+		const config = ads.config();
 		assert.equal(config.gpt.site, 'ft.com');
 		assert.equal(config.gpt.zone, 'companies/technology');
-  	done();
+		done();
 	});
 
 });
 
 QUnit.test('does not overwrite the config gpt zone with the adunit from the page response by default', function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.content);
 
-  fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
+	fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
 
-  const ads = this.ads.init({
+	const ads = this.ads.init({
 		targetingApi: {
 			page: 'https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM='
-    },
+		},
 		gpt: {
 			network: '5887',
 			site: 'ft.com',
@@ -312,153 +315,153 @@ QUnit.test('does not overwrite the config gpt zone with the adunit from the page
 	});
 
 
-  ads.then((ads) => {
-    const targeting = ads.targeting.get();
-    const config = ads.config();
+	ads.then((ads) => {
+		const targeting = ads.targeting.get();
+		const config = ads.config();
 		assert.equal(config.gpt.site, 'ft.com');
 		assert.equal(config.gpt.zone, 'old/zone');
-  	done();
+		done();
 	});
 
 });
 
 QUnit.test('does not overwrite the config gpt zone if using adUnit instead of site/zone', function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.content);
 
-  fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
+	fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
 
-  const ads = this.ads.init({
+	const ads = this.ads.init({
 		targetingApi: {
 			page: 'https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM='
-    },
+		},
 		gpt: {
 			adUnit: '5887/ft.com/site/zone'
 		}
 	});
 
 
-  ads.then((ads) => {
-    const targeting = ads.targeting.get();
-    const config = ads.config();
+	ads.then((ads) => {
+		const targeting = ads.targeting.get();
+		const config = ads.config();
 		assert.equal(config.gpt.adUnit, '5887/ft.com/site/zone');
 		assert.equal(config.gpt.zone, undefined);
-  	done();
+		done();
 	});
 
 });
 
 QUnit.test("allows single page app to update the user targeting from API on the fly", function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const userJSON = JSON.stringify(this.fixtures.user);
 
-  // mocks api response
-  const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/user', userJSON)
+	// mocks api response
+	const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/user', userJSON)
 
-  let ads = this.ads.init({
+	let ads = this.ads.init({
 		targetingApi: {
 			user: 'https://ads-api.ft.com/v1/user',
-    },
-    krux: {
-      id: '1234'
-    }
+		},
+		krux: {
+			id: '1234'
+		}
 	});
 
-  ads.then((ads) => {
-    // get config and targeting
-    const targeting = ads.targeting.get();
-    const config = ads.config();
+	ads.then((ads) => {
+		// get config and targeting
+		const targeting = ads.targeting.get();
+		const config = ads.config();
 
-    // expectations
-    const dfp_targeting =  {
-          "device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
-          "guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
-          "slv": "int",
-          "loggedIn": true,
-          "gender": "F"
-    };
-    const krux_targeting =  {
-            "user": {
-            "device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
-            "guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
-            "subscription_level": "int",
-            "loggedIn": true,
-            "gender": "F"
-          }
-    };
+		// expectations
+		const dfp_targeting =  {
+					"device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
+					"guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
+					"slv": "int",
+					"loggedIn": true,
+					"gender": "F"
+		};
+		const krux_targeting =  {
+						"user": {
+						"device_spoor_id": "cis61kpxo00003k59j4xnd8kx",
+						"guid": "d1359df2-4fe6-4dd6-bb11-eb4342f352ec",
+						"subscription_level": "int",
+						"loggedIn": true,
+						"gender": "F"
+					}
+		};
 		const lastCallOpts = apiCallMock.lastCall()[1];
 		assert.equal(lastCallOpts.credentials, "include");
 		assert.equal(lastCallOpts.timeout, 2000);
 		assert.equal(lastCallOpts.useCorsProxy, true);
 
-    // assertions
-    Object.keys(dfp_targeting).forEach((key) => {
-      assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
-    });
-    assert.deepEqual(ads.krux.customAttributes.user, krux_targeting.user, 'the krux attributes are correct');
+		// assertions
+		Object.keys(dfp_targeting).forEach((key) => {
+			assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
+		});
+		assert.deepEqual(ads.krux.customAttributes.user, krux_targeting.user, 'the krux attributes are correct');
 
 
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    // ABOVE IS COPIED FROM PREVIOUS TEST AND JUST A NORMAL EXPECTED BEHAVIOUR                    //
-    // CODE BELOW THIS LINE WILL EXPECT A CALL TO API IN ORDER TO UPDATE KRUX AND USER TARGETING  //
-    ////////////////////////////////////////////////////////////////////////////////////////////////
+		////////////////////////////////////////////////////////////////////////////////////////////////
+		// ABOVE IS COPIED FROM PREVIOUS TEST AND JUST A NORMAL EXPECTED BEHAVIOUR                    //
+		// CODE BELOW THIS LINE WILL EXPECT A CALL TO API IN ORDER TO UPDATE KRUX AND USER TARGETING  //
+		////////////////////////////////////////////////////////////////////////////////////////////////
 
-    // mock the API response with a new user data (or anonymous)
-    const userAnonymousJSON = JSON.stringify(this.fixtures.userAnonymous);
-    fetchMock.restore().mock('https://ads-api.ft.com/v1/user', userAnonymousJSON);
+		// mock the API response with a new user data (or anonymous)
+		const userAnonymousJSON = JSON.stringify(this.fixtures.userAnonymous);
+		fetchMock.restore().mock('https://ads-api.ft.com/v1/user', userAnonymousJSON);
 
 		ads.api.reset();
-    ads.api.init({ user: 'https://ads-api.ft.com/v1/user'}, ads).then(() => {
+		ads.api.init({ user: 'https://ads-api.ft.com/v1/user'}, ads).then(() => {
 
-      // same as above, get the targeting and config based in order to test
-      const targeting = ads.targeting.get();
-      const config = ads.config();
+			// same as above, get the targeting and config based in order to test
+			const targeting = ads.targeting.get();
+			const config = ads.config();
 
-      // define the new expectations
-      const dfp_targeting_anon =  {
-            "slv": "anon",
-            "loggedIn": false
-      };
+			// define the new expectations
+			const dfp_targeting_anon =  {
+						"slv": "anon",
+						"loggedIn": false
+			};
 
-      const krux_targeting_anon =  {
-              "user": {
-            }
-      };
-      // run the assertions
-      Object.keys(dfp_targeting_anon).forEach((key) => {
-        assert.equal(dfp_targeting_anon[key], targeting[key], 'the dfp is added as targeting');
-      });
-      // make sure we have removed old keys (thats where anonymous user helps)
-      assert.notOk(targeting['device_spoor_id'], 'previous user dfp keys have been removed');
+			const krux_targeting_anon =  {
+							"user": {
+						}
+			};
+			// run the assertions
+			Object.keys(dfp_targeting_anon).forEach((key) => {
+				assert.equal(dfp_targeting_anon[key], targeting[key], 'the dfp is added as targeting');
+			});
+			// make sure we have removed old keys (thats where anonymous user helps)
+			assert.notOk(targeting['device_spoor_id'], 'previous user dfp keys have been removed');
 
-      assert.deepEqual(ads.krux.customAttributes.user, krux_targeting_anon.user, 'the krux attributes are correct');
-      // make sure we have removed old keys (thats where anonymous user helps)
-      assert.notOk(ads.krux.customAttributes.user['device_spoor_id'], 'previous user krux keys have been removed');
+			assert.deepEqual(ads.krux.customAttributes.user, krux_targeting_anon.user, 'the krux attributes are correct');
+			// make sure we have removed old keys (thats where anonymous user helps)
+			assert.notOk(ads.krux.customAttributes.user['device_spoor_id'], 'previous user krux keys have been removed');
 
-      done();
-    });
+			done();
+		});
 
 
-  });
+	});
 
 });
 
 
 
 QUnit.test("Single Page app can update page context data", function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.content);
 
-  const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
+	const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
 
-  const ads = this.ads.init({
+	const ads = this.ads.init({
 		targetingApi: {
 			page: 'https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM='
-    },
-    krux: {
-      id: '1234'
-    }
+		},
+		krux: {
+			id: '1234'
+		}
 	});
 
 
@@ -467,60 +470,60 @@ QUnit.test("Single Page app can update page context data", function(assert) {
 	assert.equal(lastCallOpts.timeout, 2000);
 	assert.equal(lastCallOpts.useCorsProxy, true);
 
-  ads.then((ads) => {
-    const targeting = ads.targeting.get();
-    const config = ads.config();
-    const dfp_targeting =  {
-          "auuid": "13abbe62-70db-11e6-a0c9-1365ce54b926",
-          "ad": "ft11,s03,sm01,s05,s04,ft13",
-          "ca": "finance,company,business"
-    };
-    const krux_targeting =  {
-      "authors": ["Jung-a Song"],
-      "genre": ["News"],
-      "primarySection": ["Technology"],
-      "specialReports": [],
-      "topics": ["Mobile devices", "Batteries"]
-    };
+	ads.then((ads) => {
+		const targeting = ads.targeting.get();
+		const config = ads.config();
+		const dfp_targeting =  {
+					"auuid": "13abbe62-70db-11e6-a0c9-1365ce54b926",
+					"ad": "ft11,s03,sm01,s05,s04,ft13",
+					"ca": "finance,company,business"
+		};
+		const krux_targeting =  {
+			"authors": ["Jung-a Song"],
+			"genre": ["News"],
+			"primarySection": ["Technology"],
+			"specialReports": [],
+			"topics": ["Mobile devices", "Batteries"]
+		};
 
-    Object.keys(dfp_targeting).forEach((key) => {
-      assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
-    });
+		Object.keys(dfp_targeting).forEach((key) => {
+			assert.equal(dfp_targeting[key], targeting[key], 'the dfp is added as targeting');
+		});
 
-    assert.deepEqual(ads.krux.customAttributes.page, krux_targeting, 'the krux attributes are correct');
+		assert.deepEqual(ads.krux.customAttributes.page, krux_targeting, 'the krux attributes are correct');
 
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    // ABOVE IS COPIED FROM PREVIOUS TEST AND JUST A NORMAL EXPECTED BEHAVIOUR                    //
-    // CODE BELOW THIS LINE WILL EXPECT A CALL TO API IN ORDER TO UPDATE TARGETING                //
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    const anotherContentJSON = JSON.stringify(this.fixtures.anotherContent);
-    const apiCallMock2 = fetchMock.get('https://ads-api.ft.com/v1/concept/anotherId', anotherContentJSON)
+		////////////////////////////////////////////////////////////////////////////////////////////////
+		// ABOVE IS COPIED FROM PREVIOUS TEST AND JUST A NORMAL EXPECTED BEHAVIOUR                    //
+		// CODE BELOW THIS LINE WILL EXPECT A CALL TO API IN ORDER TO UPDATE TARGETING                //
+		////////////////////////////////////////////////////////////////////////////////////////////////
+		const anotherContentJSON = JSON.stringify(this.fixtures.anotherContent);
+		const apiCallMock2 = fetchMock.get('https://ads-api.ft.com/v1/concept/anotherId', anotherContentJSON)
 		ads.api.reset();
-    ads.api.init({ page: 'https://ads-api.ft.com/v1/concept/anotherId'}, ads).then(function() {
+		ads.api.init({ page: 'https://ads-api.ft.com/v1/concept/anotherId'}, ads).then(function() {
 
-      const targeting = ads.targeting.get();
-      const config = ads.config();
-      const dfp_targeting_updated =  {
-            "auuid": "11111111-2222-3333-4444-555555555555",
-            "ad": "s03,sm01",
-            "ca": "random,answers,here"
-      };
-      const krux_targeting_updated =  {
-        "authors": ["Jung-a Song1"],
-        "genre": ["News2"],
-        "primarySection": ["Technology3"],
-        "specialReports": [],
-        "topics": ["Mobile devices4", "Batteries5"]
-      };
+			const targeting = ads.targeting.get();
+			const config = ads.config();
+			const dfp_targeting_updated =  {
+						"auuid": "11111111-2222-3333-4444-555555555555",
+						"ad": "s03,sm01",
+						"ca": "random,answers,here"
+			};
+			const krux_targeting_updated =  {
+				"authors": ["Jung-a Song1"],
+				"genre": ["News2"],
+				"primarySection": ["Technology3"],
+				"specialReports": [],
+				"topics": ["Mobile devices4", "Batteries5"]
+			};
 
-      Object.keys(dfp_targeting_updated).forEach((key) => {
-        assert.equal(dfp_targeting_updated[key], targeting[key], 'the dfp is added as targeting');
-      });
+			Object.keys(dfp_targeting_updated).forEach((key) => {
+				assert.equal(dfp_targeting_updated[key], targeting[key], 'the dfp is added as targeting');
+			});
 
-      assert.deepEqual(ads.krux.customAttributes.page, krux_targeting_updated, 'the krux attributes are correct');
-      done();
-    });
+			assert.deepEqual(ads.krux.customAttributes.page, krux_targeting_updated, 'the krux attributes are correct');
+			done();
+		});
 
 	});
 
@@ -531,15 +534,15 @@ QUnit.test("Single Page app can update page context data", function(assert) {
 
 
 QUnit.skip("allows single page app to update the concept targeting from API on the fly", function(assert) {
-  const done = assert.async();
+	const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.concept);
 
-  fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
+	fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON)
 
-  const ads = this.ads.init({
+	const ads = this.ads.init({
 		targetingApi: {
 			page: 'https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM='
-    },
+		},
 		gpt: {
 			network: '5887',
 			site: 'ft.com',
@@ -548,24 +551,24 @@ QUnit.skip("allows single page app to update the concept targeting from API on t
 	});
 
 
-  ads.then((ads) => {
-    const targeting = ads.targeting.get();
-    const config = ads.config();
+	ads.then((ads) => {
+		const targeting = ads.targeting.get();
+		const config = ads.config();
 		assert.equal(config.gpt.site, 'ft.com');
 		assert.equal(config.gpt.zone, 'old/zone');
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    // ABOVE IS COPIED FROM PREVIOUS TEST AND JUST A NORMAL EXPECTED BEHAVIOUR                    //
-    // CODE BELOW THIS LINE WILL EXPECT A CALL TO API IN ORDER TO UPDATE TARGETING                //
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    // PROBABLY PUT METHOD ELSEWHERE AND NAME IT MORE APPROPRIETLY
-    ads.getConceptTargetingFromServer('https://ads-api.ft.com/v1/concept/anotherId').then(function() {
-      const targeting_updated = ads.targeting.get();
-      const config_updated = ads.config();
-      assert.equal(config_updated.gpt.site, 'ft.com');
-      assert.equal(config_updated.gpt.zone, 'work.and.career');
-      done();
-    });
+		////////////////////////////////////////////////////////////////////////////////////////////////
+		// ABOVE IS COPIED FROM PREVIOUS TEST AND JUST A NORMAL EXPECTED BEHAVIOUR                    //
+		// CODE BELOW THIS LINE WILL EXPECT A CALL TO API IN ORDER TO UPDATE TARGETING                //
+		////////////////////////////////////////////////////////////////////////////////////////////////
+		// PROBABLY PUT METHOD ELSEWHERE AND NAME IT MORE APPROPRIETLY
+		ads.getConceptTargetingFromServer('https://ads-api.ft.com/v1/concept/anotherId').then(function() {
+			const targeting_updated = ads.targeting.get();
+			const config_updated = ads.config();
+			assert.equal(config_updated.gpt.site, 'ft.com');
+			assert.equal(config_updated.gpt.zone, 'work.and.career');
+			done();
+		});
 
 	});
 

--- a/test/qunit/api.test.js
+++ b/test/qunit/api.test.js
@@ -194,6 +194,22 @@ QUnit.test("makes api call to correct page/content url and adds correct data to 
 
 });
 
+QUnit.test("makes use of custom set timeout when calling getPageData directly", function(assert) {
+  const done = assert.async();
+	const pageJSON = JSON.stringify(this.fixtures.content);
+
+  const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/content/16502d40-3559-11e7-99bd-13beb0903fa3');
+
+  const ads = this.ads.api.getPageData('16502d40-3559-11e7-99bd-13beb0903fa3', 300);
+
+
+	const lastCallOpts = apiCallMock.lastCall()[1];
+	assert.equal(lastCallOpts.credentials, null);
+	assert.equal(lastCallOpts.timeout, 300);
+	assert.equal(lastCallOpts.useCorsProxy, true);
+
+});
+
 QUnit.test("does not overwrite existing data in page config", function(assert) {
   const done = assert.async();
 	const userJSON = JSON.stringify(this.fixtures.user);
@@ -554,5 +570,3 @@ QUnit.skip("allows single page app to update the concept targeting from API on t
 	});
 
 });
-
-

--- a/test/qunit/api.test.js
+++ b/test/qunit/api.test.js
@@ -200,7 +200,7 @@ QUnit.test("makes use of custom set timeout when calling getPageData directly", 
 
   const apiCallMock = fetchMock.get('https://ads-api.ft.com/v1/content/16502d40-3559-11e7-99bd-13beb0903fa3', pageJSON);
 
-  const ads = this.ads.api.getPageData('16502d40-3559-11e7-99bd-13beb0903fa3', 300);
+  const ads = this.ads.api.getPageData('https://ads-api.ft.com/v1/content/16502d40-3559-11e7-99bd-13beb0903fa3', 300);
 
 
 	const lastCallOpts = apiCallMock.lastCall()[1];

--- a/test/qunit/krux.test.js
+++ b/test/qunit/krux.test.js
@@ -276,62 +276,17 @@ QUnit.test('resetAttributes resets all attributes', function(assert) {
 
 });
 
-QUnit.test('resetAttributes with a valid array of attributes resets just those', function(assert) {
+QUnit.test('resetSpecificAttributes resets just that attribute', function(assert) {
 	this.ads.krux.add({user: { "key": "value" }, page: { "key1": "value", "key2": false }, custom: { "key": "value" }});
 
 	this.ads.init({ krux: { id: '112233' }});
 	assert.ok(window.Krux.withArgs("set", "user_attr_key", "value").calledOnce, "user attributes sent to Krux");
 
-	this.ads.krux.resetAttributes(['user', 'page']);
-
-	assert.ok(window.Krux.withArgs("set", "user_attr_key", null).calledOnce, "user attributes nulled out");
-	assert.ok(window.Krux.withArgs("set", "page_attr_key1", null).calledOnce, "page attributes nulled out");
-	assert.ok(window.Krux.withArgs("set", "page_attr_key2", null).calledOnce, "page attributes nulled out");
-	assert.notOk(window.Krux.withArgs("set", "key", null).calledOnce, "custom attributes nulled out");
-
-});
-
-QUnit.test('resetAttributes with an array of attributes only resets valid keys', function(assert) {
-	this.ads.krux.add({user: { "key": "value" }, page: { "key1": "value", "key2": false }, custom: { "key": "value" }});
-
-	this.ads.init({ krux: { id: '112233' }});
-	assert.ok(window.Krux.withArgs("set", "user_attr_key", "value").calledOnce, "user attributes sent to Krux");
-
-	this.ads.krux.resetAttributes(['notValid', 'page']);
+	this.ads.krux.resetSpecificAttribute('page');
 
 	assert.notOk(window.Krux.withArgs("set", "user_attr_key", null).calledOnce, "user attributes nulled out");
 	assert.ok(window.Krux.withArgs("set", "page_attr_key1", null).calledOnce, "page attributes nulled out");
 	assert.ok(window.Krux.withArgs("set", "page_attr_key2", null).calledOnce, "page attributes nulled out");
-	assert.notOk(window.Krux.withArgs("set", "key", null).calledOnce, "custom attributes nulled out");
-
-});
-
-QUnit.test('resetAttributes with a string attribute will still work if valid key', function(assert) {
-	this.ads.krux.add({user: { "key": "value" }, page: { "key1": "value", "key2": false }, custom: { "key": "value" }});
-
-	this.ads.init({ krux: { id: '112233' }});
-	assert.ok(window.Krux.withArgs("set", "user_attr_key", "value").calledOnce, "user attributes sent to Krux");
-
-	this.ads.krux.resetAttributes('page');
-
-	assert.notOk(window.Krux.withArgs("set", "user_attr_key", null).calledOnce, "user attributes nulled out");
-	assert.ok(window.Krux.withArgs("set", "page_attr_key1", null).calledOnce, "page attributes nulled out");
-	assert.ok(window.Krux.withArgs("set", "page_attr_key2", null).calledOnce, "page attributes nulled out");
-	assert.notOk(window.Krux.withArgs("set", "key", null).calledOnce, "custom attributes nulled out");
-
-});
-
-QUnit.test('resetAttributes with a non-array attribute will not do anything if not valid key', function(assert) {
-	this.ads.krux.add({user: { "key": "value" }, page: { "key1": "value", "key2": false }, custom: { "key": "value" }});
-
-	this.ads.init({ krux: { id: '112233' }});
-	assert.ok(window.Krux.withArgs("set", "user_attr_key", "value").calledOnce, "user attributes sent to Krux");
-
-	this.ads.krux.resetAttributes(true);
-
-	assert.notOk(window.Krux.withArgs("set", "user_attr_key", null).calledOnce, "user attributes nulled out");
-	assert.notOk(window.Krux.withArgs("set", "page_attr_key1", null).calledOnce, "page attributes nulled out");
-	assert.notOk(window.Krux.withArgs("set", "page_attr_key2", null).calledOnce, "page attributes nulled out");
 	assert.notOk(window.Krux.withArgs("set", "key", null).calledOnce, "custom attributes nulled out");
 
 });

--- a/test/qunit/krux.test.js
+++ b/test/qunit/krux.test.js
@@ -275,3 +275,63 @@ QUnit.test('resetAttributes resets all attributes', function(assert) {
 	assert.ok(window.Krux.withArgs("set", "key", null).calledOnce, "custom attributes nulled out");
 
 });
+
+QUnit.test('resetAttributes with a valid array of attributes resets just those', function(assert) {
+	this.ads.krux.add({user: { "key": "value" }, page: { "key1": "value", "key2": false }, custom: { "key": "value" }});
+
+	this.ads.init({ krux: { id: '112233' }});
+	assert.ok(window.Krux.withArgs("set", "user_attr_key", "value").calledOnce, "user attributes sent to Krux");
+
+	this.ads.krux.resetAttributes(['user', 'page']);
+
+	assert.ok(window.Krux.withArgs("set", "user_attr_key", null).calledOnce, "user attributes nulled out");
+	assert.ok(window.Krux.withArgs("set", "page_attr_key1", null).calledOnce, "page attributes nulled out");
+	assert.ok(window.Krux.withArgs("set", "page_attr_key2", null).calledOnce, "page attributes nulled out");
+	assert.notOk(window.Krux.withArgs("set", "key", null).calledOnce, "custom attributes nulled out");
+
+});
+
+QUnit.test('resetAttributes with an array of attributes only resets valid keys', function(assert) {
+	this.ads.krux.add({user: { "key": "value" }, page: { "key1": "value", "key2": false }, custom: { "key": "value" }});
+
+	this.ads.init({ krux: { id: '112233' }});
+	assert.ok(window.Krux.withArgs("set", "user_attr_key", "value").calledOnce, "user attributes sent to Krux");
+
+	this.ads.krux.resetAttributes(['notValid', 'page']);
+
+	assert.notOk(window.Krux.withArgs("set", "user_attr_key", null).calledOnce, "user attributes nulled out");
+	assert.ok(window.Krux.withArgs("set", "page_attr_key1", null).calledOnce, "page attributes nulled out");
+	assert.ok(window.Krux.withArgs("set", "page_attr_key2", null).calledOnce, "page attributes nulled out");
+	assert.notOk(window.Krux.withArgs("set", "key", null).calledOnce, "custom attributes nulled out");
+
+});
+
+QUnit.test('resetAttributes with a string attribute will still work if valid key', function(assert) {
+	this.ads.krux.add({user: { "key": "value" }, page: { "key1": "value", "key2": false }, custom: { "key": "value" }});
+
+	this.ads.init({ krux: { id: '112233' }});
+	assert.ok(window.Krux.withArgs("set", "user_attr_key", "value").calledOnce, "user attributes sent to Krux");
+
+	this.ads.krux.resetAttributes('page');
+
+	assert.notOk(window.Krux.withArgs("set", "user_attr_key", null).calledOnce, "user attributes nulled out");
+	assert.ok(window.Krux.withArgs("set", "page_attr_key1", null).calledOnce, "page attributes nulled out");
+	assert.ok(window.Krux.withArgs("set", "page_attr_key2", null).calledOnce, "page attributes nulled out");
+	assert.notOk(window.Krux.withArgs("set", "key", null).calledOnce, "custom attributes nulled out");
+
+});
+
+QUnit.test('resetAttributes with a non-array attribute will not do anything if not valid key', function(assert) {
+	this.ads.krux.add({user: { "key": "value" }, page: { "key1": "value", "key2": false }, custom: { "key": "value" }});
+
+	this.ads.init({ krux: { id: '112233' }});
+	assert.ok(window.Krux.withArgs("set", "user_attr_key", "value").calledOnce, "user attributes sent to Krux");
+
+	this.ads.krux.resetAttributes(true);
+
+	assert.notOk(window.Krux.withArgs("set", "user_attr_key", null).calledOnce, "user attributes nulled out");
+	assert.notOk(window.Krux.withArgs("set", "page_attr_key1", null).calledOnce, "page attributes nulled out");
+	assert.notOk(window.Krux.withArgs("set", "page_attr_key2", null).calledOnce, "page attributes nulled out");
+	assert.notOk(window.Krux.withArgs("set", "key", null).calledOnce, "custom attributes nulled out");
+
+});


### PR DESCRIPTION
- Ability to reset only specific Krux attributes (eg. page)
- Ability to set a custom timeout for getPageData request to ads-api