### PR TITLE
Amend: clear targeting before updating

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -97,6 +97,7 @@ function setPageTargeting(targetingData) {
 	if (utils.isPlainObject(targetingData)) {
 		googletag.cmd.push(() => {
 			const pubads = googletag.pubads();
+			pubads.clearTargeting();
 			Object.keys(targetingData).forEach(key => {
 				pubads.setTargeting(key, targetingData[key])
 			});

--- a/test/qunit/gpt.test.js
+++ b/test/qunit/gpt.test.js
@@ -78,7 +78,7 @@ QUnit.test('unsetting page targeting catches and warns when about to unset all o
 	this.ads.init();
 
 	this.ads.gpt.clearPageTargetingForKey();
-	assert.equal(googletag.pubads().clearTargeting.callCount, 0, 'all params are not accidentally cleared');
+	assert.ok(errorSpy.calledWith('Refusing to unset all keys - a key must be specified'), 'all params are not accidentally cleared');
 
 	// delete mock
 	delete window.googletag;


### PR DESCRIPTION
in the updateTargeting() function we over write existing values with new ones passed in. However existing values with no new values retain the existing value.

But the desired behaviour is to remove the keys / values not in the new set passed in to the update.

This PR implements the clearTargeting() function before setting the new keys / values.