### PR TITLE
Fix: dont clear gpt targeting when overriding

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -97,7 +97,6 @@ function setPageTargeting(targetingData) {
 	if (utils.isPlainObject(targetingData)) {
 		googletag.cmd.push(() => {
 			const pubads = googletag.pubads();
-			pubads.clearTargeting();
 			Object.keys(targetingData).forEach(key => {
 				pubads.setTargeting(key, targetingData[key])
 			});
@@ -466,6 +465,10 @@ function updateCorrelator() {
 function updatePageTargeting(override) {
 	if (window.googletag) {
 		const params = utils.isPlainObject(override) ? override : targeting.get();
+		if (!override) {
+			const pubads = googletag.pubads();
+			pubads.clearTargeting();
+		}
 		setPageTargeting(params);
 	}
 	else {


### PR DESCRIPTION
Fix for this issue;

https://trello.com/c/xikmgrcY/146-all-targeting-except-res-are-missing-when-resizing-browser-in-all-pages

Introduced when implementing page targeting for webApp, we cleared existing values before updating so attributes that were to be removed would be.

However when passing in an override object we should not clear the existing values and just add the new ones.