### PR TITLE
bug fix - pubads().clearTargeting was being called incorrectly 

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -466,8 +466,9 @@ function updatePageTargeting(override) {
 	if (window.googletag) {
 		const params = utils.isPlainObject(override) ? override : targeting.get();
 		if (!override) {
-			const pubads = googletag.pubads();
-			pubads.clearTargeting();
+			googletag.cmd.push(() => {
+				googletag.pubads().clearTargeting();
+			});
 		}
 		setPageTargeting(params);
 	}


### PR DESCRIPTION
@fenglish @rowanbeentje 
bug fix - pubads().clearTargeting was being called incorrectly and called before pubads lib loaded