### PR TITLE
If the root of the observer no longer exists, reset the observer prop…

### DIFF
--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -308,6 +308,10 @@ Slots.prototype.initPostMessage = function() {
 
 Slots.prototype.initLazyLoading = function(slotConfig) {
 	const lazyLoadingConfig = config('lazyLoad') || slotConfig;
+	// reset the observer if it is tied to a since-removed root
+	if (this.lazyLoadObserver && this.lazyLoadObserver.root && !(document.contains(this.lazyLoadObserver.root))) {
+			this.lazyLoadObserver = null;
+	}
 	// If we don't already have an instance of the observer, and it is enabled globally or on a slot (force), then create one.
 	/* istanbul ignore else	*/
 	if('IntersectionObserver' in window && !this.lazyLoadObserver && !!lazyLoadingConfig) {


### PR DESCRIPTION
This change checks whether the root of the intersection observer is still in the document.

Problem: intersection observer must have the scrollable area as its root as that is what gets scrolled and fires the callback. However, in the app this scrollable area gets destroyed as you swipe around the app. o-ads sets up one intersection observer on `slots` not one on each `slot`. FT.com front-page lazy loads ads so we can't destroy it from `slots`. Therefore if you don't destroy it, it will end up tied to an element that no longer exists and never fire again as long as slots won't (re)create it.


