### PR TITLE
Handle encoded ftconsent cookies

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,21 +18,21 @@ Ads.prototype.utils = require('./src/js/utils');
 */
 
 	const getConsents = () => {
-	    // derive consent options from ft consent cookie
-	    const re = /FTConsent=([^;]+)/;
-	    const match = document.cookie.match(re);
-	    if (!match) {
-	        // cookie stasis or no consent cookie found
-	        return {
-	            behavioral : false,
-	            programmatic : "n"
-	        };
-	    }
-	    const consentCookie = match[1];
-	    return {
-	        behavioral: consentCookie.indexOf('behaviouraladsOnsite:on') !== -1,
-	        programmatic: consentCookie.indexOf('programmaticadsOnsite:on') !== -1 ? "y" : "n"
-	    };
+		// derive consent options from ft consent cookie
+		const re = /FTConsent=([^;]+)/;
+		const match = document.cookie.match(re);
+		if (!match) {
+			// cookie stasis or no consent cookie found
+			return {
+				behavioral : false,
+				programmatic : "n"
+			};
+		}
+		const consentCookie = match[1];
+		return {
+			behavioral: consentCookie.indexOf('behaviouraladsOnsite:on') !== -1,
+			programmatic: consentCookie.indexOf('programmaticadsOnsite:on') !== -1 ? "y" : "n"
+		};
 	};
 
 	Ads.prototype.init = function(options) {
@@ -102,7 +102,7 @@ Ads.prototype.updateContext = function(options, isNewPage) {
 Ads.prototype.initLibrary = function() {
 	this.slots.init();
 	this.gpt.init();
- 	if (this.consents.behavioral) {this.krux.init();}
+	if (this.consents.behavioral) {this.krux.init();}
 	if (this.consents.programmatic) {this.targeting.add({"cc" : this.consents.programmatic});}
 	this.utils.on('debug', this.debug.bind(this));
 	this.isInitialised = true;

--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ Ads.prototype.utils = require('./src/js/utils');
 				programmatic : "n"
 			};
 		}
-		const consentCookie = match[1];
+		const consentCookie = decodeURIComponent(match[1]);
 		return {
 			behavioral: consentCookie.indexOf('behaviouraladsOnsite:on') !== -1,
 			programmatic: consentCookie.indexOf('programmaticadsOnsite:on') !== -1 ? "y" : "n"

--- a/test/qunit/api.test.js
+++ b/test/qunit/api.test.js
@@ -99,7 +99,7 @@ QUnit.test("does not overwrite existing data in user config", function(assert) {
 	const done = assert.async();
 	const userJSON = JSON.stringify(this.fixtures.user);
 
-	document.cookie = 'FTConsent=behaviouraladsOnsite:on,programmaticadsOnsite:on';
+	document.cookie = 'FTConsent=behaviouraladsOnsite%3Aon%2CprogrammaticadsOnsite%3Aon';
 
 	fetchMock.get('https://ads-api.ft.com/v1/user', userJSON)
 

--- a/test/qunit/main.test.js
+++ b/test/qunit/main.test.js
@@ -230,7 +230,7 @@ QUnit.test("Krux is initialised when behaviouralAds consent is present", functio
 	const done = assert.async();
 	const kruxInitSpy = this.spy(this.ads.krux, 'init');
 
-	document.cookie = 'FTConsent=behaviouraladsOnsite:on;';
+	document.cookie = 'FTConsent=behaviouraladsOnsite%3Aon;';
 
 	this.ads.init().then(() => {
 		assert.ok(kruxInitSpy.called, 'krux.init() was called');
@@ -244,7 +244,7 @@ QUnit.test("Krux is NOT initialised if behaviouralAds consent is missing", funct
 	const done = assert.async();
 	const kruxInitSpy = this.spy(this.ads.krux, 'init');
 
-	document.cookie = 'FTConsent=behaviouraladsOnsite:off;';
+	document.cookie = 'FTConsent=behaviouraladsOnsite%3Aoff;';
 
 	this.ads.init().then(() => {
 		assert.notOk(kruxInitSpy.called, 'krux.init() should NOT be called');
@@ -271,7 +271,7 @@ QUnit.test("Krux is NOT initialised if no FTConsent cookie present", function(as
 QUnit.test("Krux is deleted from localStorage if behavioural consent is missing", function(assert) {
 	const done = assert.async();
 
-	document.cookie = 'FTConsent=behaviouraladsOnsite:off;';
+	document.cookie = 'FTConsent=behaviouraladsOnsite%3Aoff;';
 
 	localStorage.setItem('kxkuid', '1234');
 	localStorage.setItem('_kxkuid', '1234');
@@ -311,7 +311,7 @@ QUnit.test("cc targeting parameter is set to 'n' when no consentCookie is presen
 
 QUnit.test("cc targeting parameter is set to 'y' consentCookie is present and programmatic consent is true", function(assert) {
 	const done = assert.async();
-	document.cookie = 'FTConsent=behaviouraladsOnsite:off,programmaticadsOnsite:on;';
+	document.cookie = 'FTConsent=behaviouraladsOnsite%3Aoff%2CprogrammaticadsOnsite%3Aon;';
 	this.ads.init().then(() => {
 		assert.equal(this.ads.targeting.get().cc, 'y');
 		done();


### PR DESCRIPTION
Commas in cookie values aren't allowed by the cookie spec, so in theory various special characters should be URL (percent) encoded in cookies.  FTConsent will be changing to always be encoded; this change will support that (but will otherwise be backwards compatible)