### PR TITLE
Slate and placeholder options

### DIFF
--- a/docs/docs/developer-guide/display.md
+++ b/docs/docs/developer-guide/display.md
@@ -119,6 +119,12 @@ As above - but should only really be used if _only_ a 250px height ad will be us
 * `.o-ads--background`
 This adds a shaded background in the slot. In principle, this is only really used when an ad is at the top of the page above a header, in order to give some indication that the empty space is intentional.
 
+* `.o-ads--slate-background`
+This is the same as `.o-ads--background` except that the background is slate (almost black).
+
+* `.o-ads--placeholder`
+This displays a backgound image (currently an ellipsis) to give the user a clear indication that something will be loaded in this place.
+
 * `.o-ads--transition`
 Adds an animation to the container to ease the UX when an ad loads.
 

--- a/main.scss
+++ b/main.scss
@@ -41,6 +41,14 @@ $o-ads-is-silent: true !default;
 		background-color: oColorsGetPaletteColor('black-20');
 	}
 
+	.o-ads--slate-background {
+		background-color: oColorsGetPaletteColor('slate');
+	}
+
+	.o-ads--placeholder {
+		background: url('https://www.ft.com/__origami/service/image/v2/images/raw/fticon:more?source=next&tint=999999,999999') 50%/25% no-repeat transparent;
+	}
+
 	.o-ads--reserve-90 {
 		@include oAdsReserve90();
 	}


### PR DESCRIPTION
New options...

* `.o-ads--slate-background`
This is the same as `.o-ads--background` except that the background is slate (almost black).

* `.o-ads--placeholder`
This displays a backgound image (currently an ellipsis) to give the user a clear indication that something will be loaded in this place.