### PR TITLE
Avoid side-effects of reading the DOM upon being imported/required

### DIFF
--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -379,9 +379,6 @@ module.exports.getTimestamp = function() {
 	].join("");
 };
 
-// capture all iframes in the page in a live node list
-const iframes = document.getElementsByTagName('iframe');
-
 /**
 * Given the window object of an iframe this method returns the o-ads slot name
 * that rendered the iframe, if the iframe was not rendered by o-ads this will
@@ -390,6 +387,8 @@ const iframes = document.getElementsByTagName('iframe');
 * @returns {String|Boolean}
 */
 module.exports.iframeToSlotName = function(iframeWindow) {
+	// capture all iframes in the page in a live node list
+	const iframes = document.getElementsByTagName('iframe');
 	let slotName;
 	let node;
 	let i = iframes.length;


### PR DESCRIPTION
iframes is only used within the iframeToSlotName function. Moving the iframes variable to be within the iframeToSlotName function means that the file will no longer try to read DOM upon being imported, this will help consumers of the module who are trying to use it in a server context where this is no DOM present such as Node.JS

