### PR TITLE
[BREAKING CHANGES] Update ads collapse config options

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -42,7 +42,7 @@ DEPENDENCIES
   minima
 
 RUBY VERSION
-   ruby 2.3.0p0
+   ruby 2.3.7p456
 
 BUNDLED WITH
-   1.12.5
+   1.16.4

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,8 @@
 title: FT Advertising
 # Build settings
 markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
 theme: minima
 baseurl: /o-ads

--- a/docs/docs/developer-guide/advanced-display.md
+++ b/docs/docs/developer-guide/advanced-display.md
@@ -16,18 +16,20 @@ By default, lazy loading is disabled.
 
 To enable lazy loading:
 
-```
+``` javascript
 oAds.config({
 	lazyLoad: true
 });
 
 oAds.config({
 	lazyLoad: {
-    viewportMargin: '0% 0% 100% 0%',
-    threshold: [0.5]
-  }
+		viewportMargin: '0% 0% 100% 0%',
+		threshold: [0.5]
+	}
 });
+```
 
+``` html
 <div class="o-ads" data-o-ads-lazy-load="false"></div>
 ```
 
@@ -35,11 +37,11 @@ There is one exception to lazy loading, which is Master/Companion. Based on the 
 
 **Options:**
 
-* `viewportMargin` - Sets a new margin within the viewport that determines at what point the advert is in view. We suggest setting this option when you want to request and display the advert just _before_ it comes into view. This works as regular margin definitions.   
+* `viewportMargin` - Sets a new margin within the viewport that determines at what point the advert is in view. We suggest setting this option when you want to request and display the advert just _before_ it comes into view. This works as regular margin definitions.
 Make sure you always specify the dimensions with either `px` or `%`, e.g. `100% 0%`, or `100px 0px`. Default is `0%`.
 
-* `threshold` - An array of values that determine at what point a callback will be triggered.  
- In this case, the threshold is a percentage of the intersection area in relation to the area of the target's bounding box (where the target is a DOM element relative to a containing element or to the top-level viewport). [Intersection Observer](https://wicg.github.io/IntersectionObserver/#dom-intersectionobserver-intersectionobserver).  
+* `threshold` - An array of values that determine at what point a callback will be triggered.
+ In this case, the threshold is a percentage of the intersection area in relation to the area of the target's bounding box (where the target is a DOM element relative to a containing element or to the top-level viewport). [Intersection Observer](https://wicg.github.io/IntersectionObserver/#dom-intersectionobserver-intersectionobserver).
  Thresholds can be any value between 0.0 and 1.0, inclusive. Default is `0`, meaning that as soon as the first pixel comes into view, the advert will be loaded.
 
 ## Invalid Traffic
@@ -48,13 +50,12 @@ The library provide the option to check for invalid traffic before serving an ad
 
 ```<script async id="moat-ivt" src="https://sejs.moatads.com/financialtimesprebidheader859796398452/yi.js"></script>```
 
-This script will append the `m_data` parameter to the ad call, with a value of 0 or 1. DFP will then use this parameter to decide whether to serve an ad or not. 
+This script will append the `m_data` parameter to the ad call, with a value of 0 or 1. DFP will then use this parameter to decide whether to serve an ad or not.
 
 To enable this feature make sure you have the script above on your page and enable the following config setting:
 
-```
+``` javascript
 oAds.config({
-	...
 	validateAdsTraffic: true,
 	...
 });
@@ -82,24 +83,71 @@ In addition - all ad slots will have an attribute added called `data-o-ads-maste
 
 A creative may not be served under one of the following circumstances:
 
-* _A bug in the creative_  
+* _A bug in the creative_
 The ad server served an ad correctly, but some bug in the creative causes it not to display anything. A common example of this would be if the ad's assets were insecure. This needs to be reported to AdOps as soon as possible - ideally with the [creative Id or line item Id]({{ site.baseurl }}/docs/developer-guide/debugging#oadsdebug)
 
-* _Collapsed ad_  
+* _Collapsed ad_
 This is when AdOps explicitly send instructions to an ad slot not to show anything. This is done via a particular creative that contains some code implemented throught [o-ads-embed](https://github.com/Financial-Times/o-ads-embed) telling it to collapse itself. It should then append the class `o-ads--empty` to the ad slot.
 
 This is done in instances where an advertiser wants exclusivity on the page, but might not have assets with all the correct sizes.
 
-* _No ad_  
+* _No ad_
 This is when the ad server fails to return any ad. This could be caused by an ad call that is missing the correct targeting parameters and ad unit. However, it _should_ be rare, as AdOps usually fall back to either programmatic advertising or House Ads.
 
-## Out-of-page
- > Out-of-page line items make it easier to serve web creatives that do not fit in a traditional banner space or browser window. They may include pop-ups and floating line items and are sometimes called interstitials.  
+## Collapsing of empty ad slots
+ There are three options available for how the ad slot should react to the absence of an ad.
 
- >To serve pop-up, pop-under, or floating creatives to your website, you’ll need to traffic the creatives using one of DFP’s built-in creative templates, and you’ll need to make sure your tags are set up properly to allow these creative types to serve.  
- [DFP traffic and serve out-of-page creatives](https://support.google.com/dfp_premium/answer/1154352?hl=en)
+`before`: The ad slot will be collapsed before the ad request until an ad is found.
+
+`after`: The ad slot will be collapsed if no ad is found after the ad request.
+
+`never`: The ad slot never collapses, even if no ad is found.
+
+By default, collapsing of empty ads is disabled (`never`).
+
+Via config for page level:
+
+
+``` javascript
+
+oAds.config({
+	collapseEmpty: "before",
+	...
+});
 
 ```
+
+Via config for a specific slot
+
+``` javascript
+oAds.config({
+	slots: {
+		outstream: {
+			collapseEmpty: "before"
+		}
+	},
+	...
+});
+```
+
+``` html
+<!-- view.html -->
+<div class="o-ads" data-o-ads-name="outstream"></div>
+```
+
+Via component
+
+``` html
+<div class="o-ads" data-o-ads-collapse-empty="before"></div>
+```
+
+## Out-of-page
+ > Out-of-page line items make it easier to serve web creatives that do not fit in a traditional banner space or browser window. They may include pop-ups and floating line items and are sometimes called interstitials.
+
+ >To serve pop-up, pop-under, or floating creatives to your website, you’ll need to traffic the creatives using one of DFP’s built-in creative templates, and you’ll need to make sure your tags are set up properly to allow these creative types to serve.
+ [DFP traffic and serve out-of-page creatives](https://support.google.com/dfp_premium/answer/1154352?hl=en)
+
+``` html
 <div data-o-ads-out-of-page="true"></div>
 ```
 

--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -6,10 +6,10 @@
 *
 * @author Robin Marr, robin.marr@ft.com
 */
-
 const config = require('../config');
 const utils = require('../utils');
 const targeting = require('../targeting');
+const DEFAULT_COLLAPSE_MODE = 'never';
 let breakpoints = false;
 /*
 //###########################
@@ -67,7 +67,7 @@ function setup(gptConfig) {
 	enableCompanions(gptConfig);
 	setRenderingMode(gptConfig);
 	setPageTargeting(targeting.get());
-	setPageCollapseEmpty(gptConfig);
+	setPageCollapseEmpty();
 	googletag.enableServices();
 	googletag.pubads().setTargeting('url', window.location.href);
 	googletag.pubads().setRequestNonPersonalizedAds(nonPersonalized);
@@ -130,22 +130,20 @@ function clearPageTargetingForKey(key) {
 
 /**
 * Sets behaviour of empty slots can be 'after', 'before' or 'never'
-* * after collapse slots that return an empty ad
-* * before collapses all slots and only displays them on
-* true is synonymous with before
-* false is synonymous with never
+* * 'after' collapse slots that return an empty ad
+* * 'before' collapses all slots and only displays them when an ad is found
+* * 'never' does not collapse any empty slot, the collapseEmptyDivs method is not called in that case
 */
-function setPageCollapseEmpty(gptConfig) {
-	const mode = gptConfig.collapseEmpty;
+function setPageCollapseEmpty() {
+	const mode = config('collapseEmpty');
 
-	if (mode === 'before' || mode === true) {
-		googletag.pubads().collapseEmptyDivs(true, true);
-	} else if (mode === 'never' || mode === false) {
-		googletag.pubads().collapseEmptyDivs(false);
-	} else { //default is after
+	if (mode === 'before') {
 		googletag.pubads().collapseEmptyDivs(true);
 	}
 
+	if (mode === 'after') {
+		googletag.pubads().collapseEmptyDivs(false);
+	}
 }
 
 /**
@@ -383,22 +381,20 @@ const slotMethods = {
 	/**
 	* Sets the GPT collapse empty mode for a given slot
 	* values can be 'after', 'before', 'never'
-	* after as in after ads have rendered is the default
-	* true is synonymous with before
-	* false is synonymous with never
 	*/
 	setCollapseEmpty: function() {
 		window.googletag.cmd.push(() => {
-			const mode = this.collapseEmpty || config('collapseEmpty');
+			const mode = this.collapseEmpty || config('collapseEmpty') || DEFAULT_COLLAPSE_MODE;
 
-			if (mode === true || mode === 'after') {
-				this.gpt.slot.setCollapseEmptyDiv(true);
-			} else if (mode === 'before') {
+			if (mode === 'before') {
 				this.gpt.slot.setCollapseEmptyDiv(true, true);
-			} else if (mode === false || mode === 'never') {
+			} else if (mode === 'after') {
+				this.gpt.slot.setCollapseEmptyDiv(true);
+			} else if (mode === 'never') {
 				this.gpt.slot.setCollapseEmptyDiv(false);
 			}
 		});
+
 		return this;
 	},
 	submitGptImpression : function() {

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -2,6 +2,7 @@ const utils = require('./utils');
 const config = require('./config');
 
 const VALID_SIZE_STRINGS = ['fluid'];
+const VALID_COLLAPSE_MODES = ['before', 'after', 'never'];
 
 const attributeParsers = {
 	sizes: function(value, sizes) {
@@ -87,6 +88,17 @@ const attributeParsers = {
 			value = true;
 		} else if (value === 'false') {
 			value = false;
+		}
+
+		return value;
+	},
+	collapseEmpty: function(value) {
+		// can I use Array.includes? clearer imo
+		const isUnknownAttribute = VALID_COLLAPSE_MODES.indexOf(value) === -1;
+
+		if (isUnknownAttribute) {
+			console.warn(`Invalid attribute ${value} used for collapse-empty attribute, please use 'before', 'after' or 'never'`)
+			return undefined;
 		}
 
 		return value;
@@ -211,6 +223,8 @@ Slot.prototype.parseAttributeConfig = function() {
 		const value = attribute.value;
 		if (name === 'formats') {
 			this[name] = attributeParsers[name](value, this.sizes);
+		} else if (name === 'collapseEmpty') {
+			this.collapseEmpty = attributeParsers.collapseEmpty(value);
 		} else if (name === 'lazyLoadThreshold' && this.lazyLoad) {
 			convertLazyLoadBooleanToObject(this);
 			this.lazyLoad.threshold = attributeParsers.lazyLoadThreshold(value);
@@ -222,8 +236,7 @@ Slot.prototype.parseAttributeConfig = function() {
 			this.sizes = attributeParsers.responsiveFormats(name, value, this.sizes);
 		} else if (/^sizes\w*/.test(name)) {
 			this.sizes = attributeParsers.responsiveSizes(name, value, this.sizes);
-		}
-		else if (this.hasOwnProperty(name)) {
+		} else if (this.hasOwnProperty(name)) {
 			this[name] = attributeParsers.base(value);
 		}
 	});

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -93,7 +93,6 @@ const attributeParsers = {
 		return value;
 	},
 	collapseEmpty: function(value) {
-		// can I use Array.includes? clearer imo
 		const isUnknownAttribute = VALID_COLLAPSE_MODES.indexOf(value) === -1;
 
 		if (isUnknownAttribute) {

--- a/test/qunit/gpt.test.js
+++ b/test/qunit/gpt.test.js
@@ -161,6 +161,15 @@ QUnit.test('component specific mode overrides default', function(assert) {
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
 });
 
+QUnit.test('component specific mode is not set if attribute value is wrong, and the config set mode is set instead', function(assert) {
+	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle" data-o-ads-collapse-empty="INVALID_PARAMETER"></div>');
+	this.ads.init({collapseEmpty: 'after'});
+	const slot = this.ads.slots.initSlot('mpu');
+	assert.ok(slot.collapseEmpty === undefined, 'collapse empty is not set when attribute value is wrong');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true), 'call collapse empty slot gpt api with correct parameters');
+});
+
 QUnit.test('named component config overrides global config', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
 	this.ads.init({ collapseEmpty: 'after', slots: { mpu: { collapseEmpty: 'before'}}});

--- a/test/qunit/gpt.test.js
+++ b/test/qunit/gpt.test.js
@@ -113,36 +113,68 @@ QUnit.test('enables companion ads', function(assert) {
 	assert.ok(googletag.companionAds().setRefreshUnfilledSlots.calledWith(true), 'companion ads api called with correct param');
 });
 
-QUnit.test('set correct collapse mode when collapseEmpty is after', function(assert) {
+QUnit.test('set correct collapse mode when config collapseEmpty is after', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
 	this.ads.init({collapseEmpty: 'after'});
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(true), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true), 'call collapse empty slot gpt api with correct parameters');
 });
 
-QUnit.test('set correct collapse mode when collapseEmpty is before', function(assert) {
+QUnit.test('set correct collapse mode when config collapseEmpty is before', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
 	this.ads.init({collapseEmpty: 'before'});
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(true, true), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
 });
 
-QUnit.test('set correct collapse mode when collapseEmpty is never', function(assert) {
+QUnit.test('set correct collapse mode when config collapseEmpty is never', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
 	this.ads.init({collapseEmpty: 'never'});
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(false), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(false), 'call collapse empty slot gpt api with correct parameters');
 });
 
-QUnit.test('set collapse mode as never if no mode is specified', function(assert) {
+QUnit.test('set collapse mode as "never" if no mode is specified', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
 	this.ads.init({});
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(false), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(false), 'call collapse empty slot gpt api with correct parameters');
+});
+
+QUnit.test('component specific mode overrides config set parameter', function(assert) {
+	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle" data-o-ads-collapse-empty="before"></div>');
+	this.ads.init({collapseEmpty: 'after'});
+	const slot = this.ads.slots.initSlot('mpu');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
+});
+
+QUnit.test('component specific mode overrides default', function(assert) {
+	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle" data-o-ads-collapse-empty="before"></div>');
+	this.ads.init({});
+	const slot = this.ads.slots.initSlot('mpu');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
+});
+
+QUnit.test('named component config overrides global config', function(assert) {
+	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
+	this.ads.init({ collapseEmpty: 'after', slots: { mpu: { collapseEmpty: 'before'}}});
+	const slot = this.ads.slots.initSlot('mpu');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
+});
+
+QUnit.test('named component config overrides default', function(assert) {
+	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
+	this.ads.init({slots: { mpu: { collapseEmpty: 'before'}}});
+	const slot = this.ads.slots.initSlot('mpu');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
 });
 
 QUnit.test('catches slot in view render event and display it if method is ready', function(assert) {

--- a/test/qunit/gpt.test.js
+++ b/test/qunit/gpt.test.js
@@ -113,19 +113,9 @@ QUnit.test('enables companion ads', function(assert) {
 	assert.ok(googletag.companionAds().setRefreshUnfilledSlots.calledWith(true), 'companion ads api called with correct param');
 });
 
-
-QUnit.test('set correct collapse mode when collapseEmpty is true', function(assert) {
-	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({collapseEmpty: true});
-	const slot = this.ads.slots.initSlot('mpu');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(true), 'call collapse empty slot gpt api with correct parameters');
-});
-
-
 QUnit.test('set correct collapse mode when collapseEmpty is after', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({collapseEmpty: true});
+	this.ads.init({collapseEmpty: 'after'});
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(true), 'call collapse empty slot gpt api with correct parameters');
@@ -139,15 +129,6 @@ QUnit.test('set correct collapse mode when collapseEmpty is before', function(as
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(true, true), 'call collapse empty slot gpt api with correct parameters');
 });
 
-
-QUnit.test('set correct collapse mode when collapseEmpty is false', function(assert) {
-	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({collapseEmpty: false});
-	const slot = this.ads.slots.initSlot('mpu');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(false), 'call collapse empty slot gpt api with correct parameters');
-});
-
 QUnit.test('set correct collapse mode when collapseEmpty is never', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
 	this.ads.init({collapseEmpty: 'never'});
@@ -156,6 +137,13 @@ QUnit.test('set correct collapse mode when collapseEmpty is never', function(ass
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(false), 'call collapse empty slot gpt api with correct parameters');
 });
 
+QUnit.test('set collapse mode as never if no mode is specified', function(assert) {
+	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
+	this.ads.init({});
+	const slot = this.ads.slots.initSlot('mpu');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
+	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWith(false), 'call collapse empty slot gpt api with correct parameters');
+});
 
 QUnit.test('catches slot in view render event and display it if method is ready', function(assert) {
 	const slotHTML = '<div data-o-ads-formats="MediumRectangle"></div>';
@@ -375,16 +363,16 @@ QUnit.test('set unit name with attribute', function(assert) {
 
 QUnit.test('collapse empty', function(assert) {
 
-	this.ads.init({gpt: {collapseEmpty: 'after'}});
-	assert.ok(googletag.pubads().collapseEmptyDivs.calledWith(true), 'after mode is set in gpt');
+	this.ads.init({collapseEmpty: 'after'});
+	assert.ok(googletag.pubads().collapseEmptyDivs.calledWith(false), 'after mode is set in gpt');
 	googletag.pubads().collapseEmptyDivs.reset();
 
-	this.ads.init({gpt: {collapseEmpty: 'before'}});
-	assert.ok(googletag.pubads().collapseEmptyDivs.calledWith(true, true), 'before mode is set in gpt');
+	this.ads.init({collapseEmpty: 'before'});
+	assert.ok(googletag.pubads().collapseEmptyDivs.calledWith(true), 'before mode is set in gpt');
 	googletag.pubads().collapseEmptyDivs.reset();
 
-	this.ads.init({gpt: {collapseEmpty: 'never'}});
-	assert.ok(googletag.pubads().collapseEmptyDivs.calledWith(false), 'never mode is set in gpt');
+	this.ads.init({collapseEmpty: 'never'});
+	assert.ok(googletag.pubads().collapseEmptyDivs.notCalled, 'never mode is set in gpt');
 });
 
 QUnit.test('submit impression', function(assert) {


### PR DESCRIPTION
In a few words, this update changes the way we set up collapsing of ads on o-ads.

From `true` / `false` to `before`, `never` and `after`

Context: There are three behaviours for ad slots when fetching ads.

1) Initially have the ad slot collapsed until an ad in found (`before`)
2) Initially have the ad slot extended, collapse it if no ad is found (`after`)
3) Never collapse the ad slot, even if no ad is found for it (`never`)

This change intends to make it simpler to have control over this behavior globally or per specific ad slot



### Changes list:

- **breaking** Change the default collapse mode to `never`. The reason for that is that it's the default that google dfp uses
- **breaking** Change the page level option in oAdsOption to root level. e.g: 

```
// before
oAds.config({
        collapseEmpty: `before`,
	gpt: {
            collapseEmpty: `before`,
        }
});

// after
oAds.config({
	collapseEmpty: `before`,
});

```

The reason behind the change is that the slot specific config was using `config.gpt.collapseEmpty` as a default,  and the page specific config was using `config.collapseEmpty`, which made it confusing as of which flag to use to set the behavior, there should be just only one default to read from.

- **breaking** Change the component attribute based option to use `before`, `after`, `never` instead of `true` and `false`. The reason for the change is to make it consistent with the config level options and reduce confusion as of what will happen. 

- Add a validator that logs a developer warning when setting the collapse option as an html attribute if the attribute isn't one of the accepted ones.

- Update documentation to add all possible uses of the feature, including the previously undocumented option to set a slot specific config via names in the config object

- Add better syntax highlighting to the docs

- Update unit tests to reflect changes.

### Things to note

- I'm unsure whether the default collapse mode should follow google's behavior or just be well documented and left as `after`, which would avoid confusion for people updating o-ads
- These change need an update to a major
- Need to make sure I can use console.warn. And what's the use of `utils.log.warn`

- [x] Need to add unit tests
- [x] Discuss as of where to set the global flag `config.collapseEmpty` or `config.gpt.collapseEmpty`
- [ ] Make a release note
- [x] Discuss what the default should be
