### PR TITLE
update ffi in gemfile.lock 1.9.14 => 1.9.24 which addresses a securit…

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     colorator (1.1.0)
-    ffi (1.9.14)
+    ffi (1.9.24)
     forwardable-extended (2.6.0)
     jekyll (3.2.1)
       colorator (~> 1.0)


### PR DESCRIPTION
Updates Gemfile.lock dependency to minor version removing a security issue on windows devices.

I updated my local jeykill with the new dependencies. the update only adressed the security issue and should not be breaking