### PR TITLE
fix: ignore build files in eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ demos/local
 reports
 test/qunit/mocks/xhr-response.js
 nightwatch-local.js
+build


### PR DESCRIPTION
Remove noisy test output when pushing.

Eslint was running against built files
![](https://puu.sh/BI9fz/37fa39636b.png)
