### PR TITLE
Fix missing return value in error handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ Ads.prototype.init = function(options) {
 			// If anything fails, default to load ads without targeting
 			this.utils.log.error(e);
 			this.utils.log.warn('There was an error with the targeting API or the Moat invalid traffic script. Loading the o-ads library anyway, but the ads may not work as expected...');
-			this.initLibrary();
+			return this.initLibrary();
 		});
 };
 

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -41,7 +41,7 @@ function log() {
  */
 module.exports.isOn = function(type) {
 	/* istanbul ignore else  */
-	const debug = localStorage.getItem('oAds') || location.search.indexOf('DEBUG=OADS') !== -1;
+	const debug = localStorage && localStorage.getItem('oAds') || location.search.indexOf('DEBUG=OADS') !== -1;
 	return debug && window.console && window.console[type];
 };
 


### PR DESCRIPTION
which should fix this error:
https://sentry.io/nextftcom/ft-next-article/issues/692313407/?query=is:unresolved%20ads


... and added defensive code for `localStorage` being undefined on certain devices:
https://sentry.io/nextftcom/ft-next-article/issues/594124052/?query=is:unresolved%20ads