### PR TITLE
Added defensive code for browsers not supporting localStorage

### DIFF
--- a/src/js/data-providers/krux.js
+++ b/src/js/data-providers/krux.js
@@ -231,7 +231,7 @@ Krux.prototype.resetAttributes = function() {
 
 Krux.prototype.consents = function() {
 	if (config('krux') && config('krux').consentState) {
-		const kuid = localStorage.getItem('kxkuid');
+		const kuid = localStorage && localStorage.getItem('kxkuid');
 		if (kuid) {
 			const consentApi = `https://consumer.krxd.net/consent/set/bcbe1a6d-fa90-4db5-b4dc-424c69802310?idt=device&dt=kxcookie&dc=1&al=1&tg=1&cd=1&sh=1&re=1&idv=${kuid}`;
 


### PR DESCRIPTION
This should fix this error. Although it's difficult to test as it requires specific Android browsers: https://sentry.io/nextftcom/ft-next-article/issues/692583869/