### PR TITLE
NOT TO BE MERGED!! Testing out a separate export for krux

### DIFF
--- a/krux.js
+++ b/krux.js
@@ -1,0 +1,3 @@
+const krux = require('./src/js/data-providers/krux');
+
+export default krux;


### PR DESCRIPTION
This would allow anyone to import only the krux module by doing:

    const krux = require('o-ads/krux');

However, at the moment, it breaks when bringing o-ads with `npm link` (and not using `bower`) because it requires a couple of dependencies that are, somehow, not pulled in:
```
* ftdomdelegate in ../ft/o-ads/src/js/data-providers/krux.js
* o-viewport in ../ft/o-ads/src/js/utils/responsive.js
```
@andrewgeorgiou1981 , @SamiTriki , @alexflorisca do you guys think this is worth pursuing?