### PR TITLE
Remove snyk check on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,6 @@ jobs:
       - run:
           name: Check bundle sizes
           command: npm run checksizes
-      - run:
-          name: Check vulnerabilities
-          command: npm run snyk-test
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@ reports
 test/qunit/mocks/xhr-response.js
 nightwatch-local.js
 build/
+node_modules
+o-ads-compiled.js

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "demo-server": "obt demo --runServer --port=3002",
     "nightwatch-bs": "node ./test/browser/config/nightwatch-local.js -c ./test/browser/config/nightwatch.conf.js",
-    "test": "snyk test && npm run test-unit && npm run test-browser-basic && npm run test-browser-extended && npm run test-browser-gecko-temp",
+    "test": "npm run test-unit && npm run test-browser-basic && npm run test-browser-extended && npm run test-browser-gecko-temp",
     "test-size": "bundlesize",
     "test-unit": "karma start karma.conf.js --single-run",
     "test-browser": "npm run test-browser-basic && npm run test-browser-extended",
@@ -20,8 +20,7 @@
     "release": "release-it",
     "version": "genversion --semi src/js/version.js",
     "obt-build": "obt install && obt build",
-    "checksizes": "npm run obt-build && bundlesize",
-    "snyk-test": "snyk test"
+    "checksizes": "npm run obt-build && bundlesize"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Running Snyk on CIrcleCI is no longer necessary since it can now run as a GitHub status check