### PR TITLE
Fix, check that iFrame exists before attempting to access/update it

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -245,13 +245,13 @@ function onRenderEnded(event) {
 	detail.serviceName = event.serviceName;
 	const iFrameEl = document.getElementById(iframeId);
 	if (iFrameEl) {
+		iFrameEl.setAttribute('tabindex', '-1');
+		iFrameEl.setAttribute('aria-hidden', 'true');
+		iFrameEl.setAttribute('role', 'presentation');
+		iFrameEl.setAttribute('title', 'Advertisement');
 		detail.iframe = iFrameEl;
-		detail.iframe.setAttribute('tabindex', '-1');
-		detail.iframe.setAttribute('aria-hidden', 'true');
-		detail.iframe.setAttribute('role', 'presentation');
-		detail.iframe.setAttribute('title', 'Advertisement');
 	} else {
-		utils.log.warn('iFrame was not found.');
+		utils.log.warn('No iFrame found matching GPT SlotID');
 	}
 	utils.broadcast('rendered', data);
 }

--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -243,8 +243,9 @@ function onRenderEnded(event) {
 	detail.creativeId = event.creativeId;
 	detail.lineItemId = event.lineItemId;
 	detail.serviceName = event.serviceName;
-	if (document.getElementById(iframeId)) {
-		detail.iframe = document.getElementById(iframeId);
+	let iFrameEl = document.getElementById(iframeId);
+	if (iFrameEl) {
+		detail.iframe = iFrameEl;
 		detail.iframe.setAttribute('tabindex', '-1');
 		detail.iframe.setAttribute('aria-hidden', 'true');
 		detail.iframe.setAttribute('role', 'presentation');

--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -243,11 +243,15 @@ function onRenderEnded(event) {
 	detail.creativeId = event.creativeId;
 	detail.lineItemId = event.lineItemId;
 	detail.serviceName = event.serviceName;
-	detail.iframe = document.getElementById(iframeId);
-	detail.iframe.setAttribute('tabindex', '-1');
-	detail.iframe.setAttribute('aria-hidden', 'true');
-	detail.iframe.setAttribute('role', 'presentation');
-	detail.iframe.setAttribute('title', 'Advertisement');
+	if (document.getElementById(iframeId)) {
+		detail.iframe = document.getElementById(iframeId);
+		detail.iframe.setAttribute('tabindex', '-1');
+		detail.iframe.setAttribute('aria-hidden', 'true');
+		detail.iframe.setAttribute('role', 'presentation');
+		detail.iframe.setAttribute('title', 'Advertisement');
+	} else {
+		utils.log.warn('iFrame was not found.');
+	}
 	utils.broadcast('rendered', data);
 }
 

--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -243,7 +243,7 @@ function onRenderEnded(event) {
 	detail.creativeId = event.creativeId;
 	detail.lineItemId = event.lineItemId;
 	detail.serviceName = event.serviceName;
-	let iFrameEl = document.getElementById(iframeId);
+	const iFrameEl = document.getElementById(iframeId);
 	if (iFrameEl) {
 		detail.iframe = iFrameEl;
 		detail.iframe.setAttribute('tabindex', '-1');


### PR DESCRIPTION
GPT provides a "renderEnded" event which fires when the ad's creative code is injected into a slot.
o-ads listens for this event and then attempts to update the iFrame of the slot.
A recent issue surfaced, where it appears that if no ad creative is returned from dfp, the iFrame was not being created. 
This appears to be a bug with GPT; however it highlighted the need to be more robust in our coding.

Specifically we will now check for the presence of the iFrame before attempting to access its properties. 