### PR TITLE
Workaround Browserstack problems with Firefox v65

### DIFF
--- a/test/browser/config/nightwatch.conf.js
+++ b/test/browser/config/nightwatch.conf.js
@@ -41,7 +41,7 @@ const config = {
 		firefox: {
 			desiredCapabilities: {
 				os: 'Windows',
-				os_version: '7',
+				os_version: '10',
 				browser: 'Firefox',
 				acceptSslCerts: true,
 				version: '64'

--- a/test/browser/config/nightwatch.conf.js
+++ b/test/browser/config/nightwatch.conf.js
@@ -44,7 +44,8 @@ const config = {
 				os_version: '10',
 				browser: 'Firefox',
 				acceptSslCerts: true,
-				version: '64'
+				version: '64',
+				host: 'bs-local.com'
 			}
 		},
 		safari: {

--- a/test/browser/config/nightwatch.conf.js
+++ b/test/browser/config/nightwatch.conf.js
@@ -41,16 +41,17 @@ const config = {
 		firefox: {
 			desiredCapabilities: {
 				os: 'Windows',
-  				os_version: '7',
+				os_version: '7',
 				browser: 'Firefox',
-				acceptSslCerts: true
+				acceptSslCerts: true,
+				version: '64'
 			}
 		},
 		safari: {
 			desiredCapabilities: {
 				'os': 'OS X',
-  				'os_version': 'High Sierra',
-  				'browser': 'Safari',
+				'os_version': 'High Sierra',
+				'browser': 'Safari',
 				acceptSslCerts: true
 			}
 		},

--- a/test/browser/config/nightwatch.conf.js
+++ b/test/browser/config/nightwatch.conf.js
@@ -44,7 +44,7 @@ const config = {
 				os_version: '10',
 				browser: 'Firefox',
 				acceptSslCerts: true,
-				version: '64',
+				version: '65',
 				host: 'bs-local.com'
 			}
 		},


### PR DESCRIPTION
Browserstack has problems at the moment with the latest Firefox (v65). I am temporarily pinning FFox to v64 until we receive confirmation that they have sorted out the problem.