### PR TITLE
Don't send a postMessage if slot is undefined

### DIFF
--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -284,7 +284,6 @@ Slots.prototype.initPostMessage = function() {
 					utils.messenger.post(messageToSend, event.source);
 				} else {
 					utils.log.error('Message received from unidentified slot');
-					utils.messenger.post(messageToSend, event.source);
 				}
 			} else {
 				if (!slot) {

--- a/test/qunit/slots.post.message.test.js
+++ b/test/qunit/slots.post.message.test.js
@@ -118,16 +118,14 @@ QUnit.test('Post message from unknown slot logs an error and sends a repsonse', 
 		return 'unknown-slot';
 	});
 
-
-	this.stub(this.utils.messenger, 'post', function (message, source) {
-		assert.ok(errorStub.calledWith('Message received from unidentified slot'), 'the error is logged');
-		assert.equal(message.type, 'oAds.youare', 'the event type is oAds.youare');
-		assert.equal(message.name, undefined, 'the name is undefined');
-		assert.deepEqual(message.sizes, undefined, 'no sizes are supplied');
-		assert.notOk(slot.collapse.called, 'the collapse method is not called');
-		assert.strictEqual(window, source, ' the source is the as expected');
-		done();
-	});
+	window.addEventListener('message', 	function () {
+		// Make sure this executes AFTER the other 'message' event listener
+		// defined in slots.js
+		setTimeout(() => {
+			assert.ok(errorStub.calledWith('Message received from unidentified slot'), 'the error is logged');
+			done();
+		}, 0);
+	 });
 
 	document.body.addEventListener('oAds.ready', 	function () {
 		window.postMessage('{ "type": "oAds.whoami"}', '*');


### PR DESCRIPTION
Ideally the `o-ads-embed` script is wrapped around the creative one time. However, I found examples of ads where the creative includes an iframe within an iframe, which is also calling `o-ads-embed`. 

```
browser window
-->  iframe1 window
         --> o-ads-embed.js
         --> iframe2 window
                 --> o-ads-embed.js
                 --> creative.png
```
`o-ads-embed` sends a postMessage to `o-ads` on the main page, on the `document.load` event of the iframe. In this case, two postMessages will be sent to `o-ads`. One from the top level iframe and the second from iframe2 (in diagram above). They will both be picked up by `o-ads`, which will try and find an ad slot in the parent window. This will work for the first` o-ads-embed`, but not the second. 

For some reason, even though we do not detect an ad slot on the second call, we send a `postMessage` back to `o-ads-embed`. This message has insufficient information and causes `o-ads-embed` to error. I think this should be removed.


