### PR TITLE
Use o-ads-embed v3 (backwards compatible)

### DIFF
--- a/demos/src/o-ads-embed.mustache
+++ b/demos/src/o-ads-embed.mustache
@@ -17,3 +17,23 @@
 			</div>
 		</div>
 	</div>
+
+<div 
+	data-o-ads-name="mid" 
+	data-o-ads-targeting="pos=mid;" 
+	data-o-ads-center="true" 
+	data-o-ads-formats-default="Billboard" 
+	data-o-ads-formats-small="Billboard" 
+	data-o-ads-formats-medium="Leaderboard,Responsive" 
+	data-o-ads-formats-large="SuperLeaderboard,Leaderboard,Responsive" 
+	data-o-ads-formats-extra="Billboard,SuperLeaderboard,Leaderboard,Responsive" 
+	data-sticky-ad="true" aria-hidden="true" data-o-ads-loaded="Billboard">
+		<div class="o-ads__outer">
+			<div class="o-ads__inner">
+				<div style="border: 0pt none;">
+					<iframe title="Advertisement" src="http://localhost:8999/demos/local/Local-Creative-Wrapper-With-Collapse.html" width="300" height="300">
+					</iframe>
+				</div>
+			</div>
+		</div>
+	</div>

--- a/demos/src/o-ads-embed.mustache
+++ b/demos/src/o-ads-embed.mustache
@@ -1,0 +1,19 @@
+<div 
+	data-o-ads-name="top" 
+	data-o-ads-targeting="pos=top;" 
+	data-o-ads-center="true" 
+	data-o-ads-formats-default="Billboard" 
+	data-o-ads-formats-small="Billboard" 
+	data-o-ads-formats-medium="Leaderboard,Responsive" 
+	data-o-ads-formats-large="SuperLeaderboard,Leaderboard,Responsive" 
+	data-o-ads-formats-extra="Billboard,SuperLeaderboard,Leaderboard,Responsive" 
+	data-sticky-ad="true" aria-hidden="true" data-o-ads-loaded="Billboard">
+		<div class="o-ads__outer">
+			<div class="o-ads__inner">
+				<div style="border: 0pt none;">
+					<iframe title="Advertisement" src="http://localhost:8999/demos/local/Local-Creative-Wrapper.html" width="300" height="300">
+					</iframe>
+				</div>
+			</div>
+		</div>
+	</div>

--- a/origami.json
+++ b/origami.json
@@ -156,6 +156,12 @@
 				"network": 5887,
 				"site" : "test.5887.origami"
 			}
+		},
+		{
+			"name": "o-ads-embed",
+			"template": "/demos/src/o-ads-embed.mustache",
+			"expanded": true,
+			"description": "Test o-ads-embed"
 		}
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "o-ads",
-  "version": "10.2.2",
+  "version": "10.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6807,7 +6807,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6828,12 +6829,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6848,17 +6851,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6975,7 +6981,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6987,6 +6994,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7001,6 +7009,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7008,12 +7017,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7032,6 +7043,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7112,7 +7124,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7124,6 +7137,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7209,7 +7223,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7245,6 +7260,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7264,6 +7280,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7307,12 +7324,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -12,7 +12,7 @@ module.exports = {
 			'demos/src/responsive-positions.mustache',
 			'demos/src/test-ad.mustache',
 			'demos/src/test-ad-responsive.mustache',
-			'demos/src/google-test.mustache',
+			'demos/src/o-ads-embed.mustache',
 			'docs/Gemfile',
 			'docs/Gemfile.lock',
 			'docs/_posts/2016-08-19-welcome-to-jekyll.markdown',

--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -301,7 +301,7 @@ const slotMethods = {
 
 				updatePageTargeting({ res: screensize });
 
-				if (slot.hasValidSize(screensize) && !slot.responsiveCreative) {
+				if (slot.hasValidSize(screensize)) {
 					/* istanbul ignore else  */
 					if (slot.gpt.iframe) {
 						slot.fire('refresh');

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -152,7 +152,6 @@ function Slot(container, screensize, initLazyLoading) {
 
 	// make sure the slot has a name
 	this.setName();
-	this.setResponsiveCreative(false);
 	slotConfig = slotConfig[this.name] || {};
 
 	// default configuration properties
@@ -316,14 +315,6 @@ Slot.prototype.setName = function() {
 		this.name = `o-ads-slot-${(Math.floor(Math.random() * 10000))}`;
 		this.container.setAttribute('data-o-ads-name', this.name);
 	}
-	return this;
-};
-
-/**
- *	If the slot doesn't have a name give it one
- */
-Slot.prototype.setResponsiveCreative = function(value) {
-	this.responsiveCreative = value;
 	return this;
 };
 

--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -254,7 +254,7 @@ Slots.prototype.initPostMessage = function() {
 				utils.log.error('Message received from unidentified slot');
 				return;
 			}
-			// For backwards compatibility with o-ads-embed v2.
+			// For backwards compatibility with o-ads-embed v2
 			if (type === 'whoami' && event.source) {
 				if (data.collapse) {
 					slot.collapse();
@@ -264,6 +264,11 @@ Slots.prototype.initPostMessage = function() {
 					name: slotName
 				};
 				utils.messenger.post(messageToSend, event.source);
+			}
+
+			// TODO: Remove adIframeLoaded once we can tag onto GPTs `slotRenderEnded` event
+			else if(type === 'adIframeLoaded') {
+				document.body.dispatchEvent( new CustomEvent('oAds.adIframeLoaded'));
 			}
 
 			// Received message to Collapse ad slot.

--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -267,7 +267,7 @@ Slots.prototype.initPostMessage = function() {
 			}
 
 			// Received message to Collapse ad slot.
-			else if (type === 'collapse' && data.collapse) {
+			else if (type === 'collapse') {
 				slot.collapse();
 			}
 

--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -255,8 +255,20 @@ Slots.prototype.initPostMessage = function() {
 				return;
 			}
 
+			// For backwards compatibility with o-ads-embed v2.
+			if (type === 'whoami' && event.source) {
+				if (data.collapse) {
+					slot.collapse();
+				}
+				const messageToSend = {
+					type: 'oAds.youare',
+					name: slotName
+				};
+				utils.messenger.post(messageToSend, event.source);
+			}
+
 			// Received message to Collapse ad slot.
-			if (type === 'collapse' && data.collapse) {
+			else if (type === 'collapse' && data.collapse) {
 				slot.collapse();
 			}
 

--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -247,14 +247,13 @@ Slots.prototype.initPostMessage = function() {
 		/* istanbul ignore else	don't process messages with a non oAds type*/
 		if (data.type && (/^oAds\./.test(data.type) || /^touch/.test(data.type))) {
 			const type = data.type.replace('oAds\.', '');
+			// Make sure the message is coming from an identified ad slot
 			const slotName = utils.iframeToSlotName(event.source.window);
 			const slot = slots[slotName] || false;
-
 			if (!slot) {
 				utils.log.error('Message received from unidentified slot');
 				return;
 			}
-
 			// For backwards compatibility with o-ads-embed v2.
 			if (type === 'whoami' && event.source) {
 				if (data.collapse) {

--- a/test/qunit/slots.post.message.test.js
+++ b/test/qunit/slots.post.message.test.js
@@ -37,7 +37,6 @@ QUnit.test('Post message whoami message reply is sent', function (assert) {
 	this.stub(this.utils.messenger, 'post', function(message, source) {
 		assert.equal(message.type, 'oAds.youare', 'the event type is oAds.youare');
 		assert.equal(message.name, slotName, 'the name is ' + slotName);
-		assert.deepEqual(message.sizes, [[300, 250]], 'the correct sizes are supplied');
 		assert.notOk(slot.collapse.called, 'the collapse method is not called');
 		assert.strictEqual(window, source, ' the source is the as expected');
 		done();
@@ -52,7 +51,7 @@ QUnit.test('Post message whoami message reply is sent', function (assert) {
 	this.spy(slot, 'collapse');
 });
 
-QUnit.test('Post message whoami message with collapse will call slot collapse', function (assert) {
+QUnit.test('Post message "whoami" message with collapse option will call slot.collapse()', function (assert) {
 	const done = assert.async();
 	const slotName = 'whoami-collapse-ad';
 	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');
@@ -63,7 +62,6 @@ QUnit.test('Post message whoami message with collapse will call slot collapse', 
 	this.stub(this.utils.messenger, 'post', function(message, source) {
 		assert.equal(message.type, 'oAds.youare', 'the event type is oAds.youare');
 		assert.equal(message.name, slotName, 'the name is ' + slotName);
-		assert.deepEqual(message.sizes, [[300, 250]], 'the sizes are returned');
 		assert.ok(slot.collapse.called, 'the collapse method is called');
 		assert.strictEqual(window, source, ' the source is the as expected');
 		done();
@@ -78,37 +76,6 @@ QUnit.test('Post message whoami message with collapse will call slot collapse', 
 	this.spy(slot, 'collapse');
 });
 
-QUnit.test('Post message whoami message with isMaster will fire event on companion slots', function (assert) {
-	const done = assert.async();
-	const master = this.fixturesContainer.add('<div data-o-ads-name="master" data-o-ads-formats="Leaderboard"></div>');
-	const companion = this.fixturesContainer.add('<div data-o-ads-name="companion" data-o-ads-companion="true" data-o-ads-formats="MediumRectangle"></div>');
-	const notCompanion = this.fixturesContainer.add('<div data-o-ads-name="not-companion" data-o-ads-formats="MediumRectangle" data-o-ads-companion="false"></div>');
-	this.stub(this.utils, 'iframeToSlotName', function () {
-		return 'master';
-	});
-
-	this.stub(this.utils.messenger, 'post', function () {
-		assert.ok(companionSlot.fire.called, 'the event is is called on the companion');
-		assert.equal(companionSlot.container.getAttribute('data-o-ads-master-loaded'), 'Leaderboard');
-		assert.notOk(masterSlot.fire.called, 'the event method is not called on the master');
-		assert.notOk(notCompanionSlot.fire.called, 'the collapse method is not called on a non companion');
-		done();
-	});
-
-	document.body.addEventListener('oAds.ready', function (slot) {
-		if(slot.detail.name === 'master') {
-			window.postMessage('{ "type": "oAds.whoami", "mastercompanion": true}', '*');
-		}
-	});
-
-	this.ads.init();
-	const masterSlot = this.ads.slots.initSlot(master);
-	const companionSlot = this.ads.slots.initSlot(companion);
-	const notCompanionSlot = this.ads.slots.initSlot(notCompanion);
-	this.spy(masterSlot, 'fire');
-	this.spy(companionSlot, 'fire');
-	this.spy(notCompanionSlot, 'fire');
-});
 
 QUnit.test('Post message from unknown slot logs an error and sends a repsonse', function (assert) {
 	const done = assert.async();
@@ -132,24 +99,7 @@ QUnit.test('Post message from unknown slot logs an error and sends a repsonse', 
  	});
 
 	this.ads.init();
-	const slot = this.ads.slots.initSlot(container);
-	this.spy(slot, 'collapse');
-});
-
-QUnit.test('Post message collapse calls the collapse method on the slot', function (assert) {
-	const done = assert.async();
-	const slotName = 'collapse-ad';
-	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');
-	document.body.addEventListener('oAds.complete', function () {
-		window.postMessage('{ "type": "oAds.collapse", "name": "' + slotName + '"}', '*');
-	});
-
-	this.ads.init();
-	const slot = this.ads.slots.initSlot(container);
-	this.stub(slot, 'collapse', function () {
-		assert.ok(slot.collapse.called, 'the collapse method is called');
-		done();
-	});
+	this.ads.slots.initSlot(container);
 });
 
 
@@ -157,6 +107,9 @@ QUnit.test('Passed touch fires an event', function (assert) {
 	const done = assert.async();
 	const slotName = 'touch-ad';
 	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="HalfPage,MediumRectangle"></div>');
+	this.stub(this.utils, 'iframeToSlotName', function () {
+		return slotName;
+	});
 
 	document.body.addEventListener('oAds.ready', function () {
 		window.postMessage('{ "type": "touchstart", "name": "' + slotName + '"}', '*');
@@ -174,7 +127,7 @@ QUnit.test('Passed touch fires an event', function (assert) {
 });
 
 
-QUnit.test('Post message catches the event when the message comes not from a slot that is does not exist', function (assert) {
+QUnit.test('Post message catches the event when the message comes from an unidentified slot', function (assert) {
 	const done = assert.async();
 	const slotName = 'responsive-ad';
 	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="HalfPage,MediumRectangle"></div>');
@@ -190,21 +143,53 @@ QUnit.test('Post message catches the event when the message comes not from a slo
 	this.ads.slots.initSlot(container);
 });
 
-QUnit.test('Post message collapse calls the collapse method on the slot', function (assert) {
+QUnit.test('Post message "collapse" message will call slot.collapse()', function (assert) {
 	const done = assert.async();
-	const slotName = 'custom-message';
+	const slotName = 'collapse-ad';
 	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');
 	this.stub(this.utils, 'iframeToSlotName', function () {
 		return slotName;
 	});
-	document.body.addEventListener('oAds.complete', function () {
-		window.postMessage('{"collapse":false,"mastercompanion":false,"customMessages":{"arrow-buttons-disabled":"true"},"type":"oAds.whoami","name":"custom-message"}', '*');
 
+	document.body.addEventListener('oAds.ready', function () {
+		window.postMessage('{ "type": "oAds.collapse", "collapse": true}', '*');
 	});
-	document.body.addEventListener("oAds.customMessages", function() {
-	 assert.equal(event.detail.name, 'custom-message', 'test slot fired the customMessages event');
-	 	done();
+
+	window.addEventListener('message', function () {
+		// Make sure this executes AFTER the other 'message' event listener
+		// defined in slots.js
+		setTimeout(() => {
+			assert.ok(slot.collapse.called, 'the collapse method is called');
+			done();
+		}, 0);
 	});
+
+	this.ads.init();
+	const slot = this.ads.slots.initSlot(container);
+	this.spy(slot, 'collapse');
+});
+
+QUnit.test('Unknown postMessage will log an error', function (assert) {
+	const done = assert.async();
+	const slotName = 'test-ad';
+	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');
+	this.stub(this.utils, 'iframeToSlotName', function () {
+		return slotName;
+	});
+
+	window.addEventListener('message', function () {
+		// Make sure this executes AFTER the other 'message' event listener
+		// defined in slots.js
+		setTimeout(() => {
+			assert.ok(errorStub.calledWith('Unknown message received from o-ads-embed'), 'the error is logged');
+			done();
+		}, 0);
+	});
+
+	document.body.addEventListener('oAds.ready', function () {
+		window.postMessage('{ "type": "oAds.unknown" }', '*');
+	});
+
 	this.ads.init();
 	this.ads.slots.initSlot(container);
 });

--- a/test/qunit/slots.post.message.test.js
+++ b/test/qunit/slots.post.message.test.js
@@ -152,43 +152,6 @@ QUnit.test('Post message collapse calls the collapse method on the slot', functi
 	});
 });
 
-QUnit.test('Post message responsive tells the slot a responsive creative is loaded', function (assert) {
-	const done = assert.async();
-	const slotName = 'responsive-ad';
-	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="HalfPage,MediumRectangle"></div>');
-
-	document.body.addEventListener('oAds.ready', function () {
-		window.postMessage('{ "type": "oAds.responsive", "name": "' + slotName + '"}', '*');
-	});
-
-	this.ads.init();
-	const slot = this.ads.slots.initSlot(container);
-	this.stub(slot, 'setResponsiveCreative', function () {
-		assert.ok(slot.setResponsiveCreative.calledWith(true), 'the setResponsiveCreative method is called');
-		done();
-	});
-});
-
-
-QUnit.test('Post message resize message fire the resize event', function (assert) {
-	const done = assert.async();
-	const slotName = 'resize-ad';
-	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="HalfPage,MediumRectangle"></div>');
-
-	document.body.addEventListener('oAds.ready', function () {
-		window.postMessage('{ "type": "oAds.resize", "name": "' + slotName + '", "size": [300, 250]}', '*');
-	});
-
-	document.body.addEventListener('oAds.resize', function () {
-		assert.ok(event.detail.slot, 'The resize event is fired ');
-		assert.equal(event.detail.name, slotName, 'the name is ' + slotName);
-		assert.deepEqual(event.detail.size, [300, 250], 'the correct size is passed');
-		done();
-	});
-
-	this.ads.init();
-	this.ads.slots.initSlot(container);
-});
 
 QUnit.test('Passed touch fires an event', function (assert) {
 	const done = assert.async();
@@ -208,79 +171,6 @@ QUnit.test('Passed touch fires an event', function (assert) {
 
 	this.ads.init();
 	this.ads.slots.initSlot(container);
-});
-
-
-QUnit.test('Post message replies with correct disable default swipe handler parameter if config is present on attribute', function (assert) {
-	const done = assert.async();
-	const slotName = 'whoami-collapse-ad';
-	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle" data-o-ads-disable-swipe-default="true"></div>');
-	this.stub(this.utils, 'iframeToSlotName', function () {
-		return slotName;
-	});
-
-	this.stub(this.utils.messenger, 'post', function (message, source) {
-		assert.equal(message.type, 'oAds.youare', 'the event type is oAds.youare');
-		assert.equal(message.name, slotName, 'the name is ' + slotName);
-		assert.equal(message.disableDefaultSwipeHandler, true, 'the default handler disable flag is present');
-		assert.strictEqual(window, source, ' the source is the as expected');
-		done();
-	});
-
-	document.body.addEventListener('oAds.ready', function () {
-		window.postMessage('{ "type": "oAds.whoami"}', '*');
-	});
-
-	this.ads.init();
-	const slot = this.ads.slots.initSlot(container);
-	this.spy(slot, 'collapse');
-});
-
-QUnit.test('Post message replies with correct disable default swipe handler parameter if config is present in slot config', function (assert) {
-	const done = assert.async();
-	const slotName = 'test';
-	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');
-	this.stub(this.utils, 'iframeToSlotName', function () {
-		return slotName;
-	});
-	this.stub(this.utils.messenger, 'post', function (message, source) {
-		assert.equal(message.type, 'oAds.youare', 'the event type is oAds.youare');
-		assert.equal(message.name, slotName, 'the name is ' + slotName);
-		assert.equal(message.disableDefaultSwipeHandler, true, 'the default handler disable flag is present');
-		assert.strictEqual(window, source, ' the source is the as expected');
-		done();
-	});
-
-	document.body.addEventListener('oAds.ready', function () {
-		window.postMessage('{ "type": "oAds.whoami"}', '*');
-	});
-	this.ads.init({slots: {test: {disableSwipeDefault: true}}});
-	const slot = this.ads.slots.initSlot(container);
-	this.spy(slot, 'collapse');
-});
-
-
-QUnit.test('Post message replies with correct disable default swipe handler parameter if config is present in global config', function (assert) {
-	const done = assert.async();
-	const slotName = 'test';
-	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');
-	this.stub(this.utils, 'iframeToSlotName', function () {
-		return slotName;
-	});
-	this.stub(this.utils.messenger, 'post', function (message, source) {
-		assert.equal(message.type, 'oAds.youare', 'the event type is oAds.youare');
-		assert.equal(message.name, slotName, 'the name is ' + slotName);
-		assert.equal(message.disableDefaultSwipeHandler, true, 'the default handler disable flag is present');
-		assert.strictEqual(window, source, ' the source is the as expected');
-		done();
-	});
-
-	document.body.addEventListener('oAds.ready', function () {
-		window.postMessage('{ "type": "oAds.whoami"}', '*');
-	});
-	this.ads.init({disableSwipeDefault: true});
-	const slot = this.ads.slots.initSlot(container);
-	this.spy(slot, 'collapse');
 });
 
 


### PR DESCRIPTION
This updates o-ads to remove some of the unused functionality from o-ads-embed. This PR goes hand in hand with the PR for `o-ads-embed` v3 (https://github.com/Financial-Times/o-ads-embed/pull/21). 

This PR keeps backwards compatibility with `o-ads-embed` v2 for collapsing ad slots and touch events (the only features in o-ads-embed v3)