### PR TITLE
Remove backwards compatibility with o-ads-embed v2

### DIFF
--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -254,21 +254,9 @@ Slots.prototype.initPostMessage = function() {
 				utils.log.error('Message received from unidentified slot');
 				return;
 			}
-			// For backwards compatibility with o-ads-embed v2
-			// TODO: remove once creative wrapper updated with o-ads-embed v3
-			if (type === 'whoami' && event.source) {
-				if (data.collapse) {
-					slot.collapse();
-				}
-				const messageToSend = {
-					type: 'oAds.youare',
-					name: slotName
-				};
-				utils.messenger.post(messageToSend, event.source);
-			}
 
 			// TODO: Remove adIframeLoaded once we can tag onto GPTs `slotRenderEnded` event
-			else if(type === 'adIframeLoaded') {
+			if(type === 'adIframeLoaded') {
 				document.body.dispatchEvent( new CustomEvent('oAds.adIframeLoaded'));
 			}
 

--- a/test/qunit/slots.post.message.test.js
+++ b/test/qunit/slots.post.message.test.js
@@ -26,57 +26,6 @@ QUnit.module('Slots - post message', {
 	}
 });
 
-QUnit.test('Post message whoami message reply is sent', function (assert) {
-	const done = assert.async();
-	const slotName = 'whoami-ad';
-	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');
-	this.stub(this.utils, 'iframeToSlotName', function () {
-		return slotName;
-	});
-
-	this.stub(this.utils.messenger, 'post', function(message, source) {
-		assert.equal(message.type, 'oAds.youare', 'the event type is oAds.youare');
-		assert.equal(message.name, slotName, 'the name is ' + slotName);
-		assert.notOk(slot.collapse.called, 'the collapse method is not called');
-		assert.strictEqual(window, source, ' the source is the as expected');
-		done();
-	});
-
-	document.body.addEventListener('oAds.ready', 	function () {
-		window.postMessage('{ "type": "oAds.whoami"}', '*');
- 	});
-
-	this.ads.init();
-	const slot = this.ads.slots.initSlot(container);
-	this.spy(slot, 'collapse');
-});
-
-QUnit.test('Post message "whoami" message with collapse option will call slot.collapse()', function (assert) {
-	const done = assert.async();
-	const slotName = 'whoami-collapse-ad';
-	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');
-	this.stub(this.utils, 'iframeToSlotName', function () {
-		return slotName;
-	});
-
-	this.stub(this.utils.messenger, 'post', function(message, source) {
-		assert.equal(message.type, 'oAds.youare', 'the event type is oAds.youare');
-		assert.equal(message.name, slotName, 'the name is ' + slotName);
-		assert.ok(slot.collapse.called, 'the collapse method is called');
-		assert.strictEqual(window, source, ' the source is the as expected');
-		done();
-	});
-
-	document.body.addEventListener('oAds.ready', function () {
-		window.postMessage('{ "type": "oAds.whoami", "collapse": true}', '*');
-	});
-
-	this.ads.init();
-	const slot = this.ads.slots.initSlot(container);
-	this.spy(slot, 'collapse');
-});
-
-
 QUnit.test('Post message from unknown slot logs an error and sends a repsonse', function (assert) {
 	const done = assert.async();
 	const slotName = 'whoami-ad';


### PR DESCRIPTION
o-ads-embed has been upgraded to v3 successfully. FT.com is the only user so we can safely remove the backwards compatibility now and tidy up.