### PR TITLE
Add moat timeout monitoring

### DIFF
--- a/src/js/data-providers/moat.js
+++ b/src/js/data-providers/moat.js
@@ -21,6 +21,7 @@ Moat.prototype.init = function() {
 		}, 50);
 		const timeoutId = setTimeout(() => {
 			clearInterval(intervalId);
+			utils.broadcast('moatTimeout');
 			reject(new Error('Timeout while fetching moat invalid traffic script'));
 		}, 1000);
 	});

--- a/test/qunit/main.test.js
+++ b/test/qunit/main.test.js
@@ -250,12 +250,14 @@ QUnit.test("moat script loading check is eventually cleared if moat is loaded", 
 });
 
 QUnit.test("moat script loading check is eventually cleared if moat is not loaded", function(assert) {
+	this.spy(this.utils, 'broadcast');
 	const clearIntSpy = this.spy(window, 'clearInterval');
 	window.moatPrebidApi = null;
 	this.ads.moat.init();
 	const done = assert.async();
 
 	setTimeout( () => {
+		assert.ok(this.ads.utils.broadcast.calledWith('moatTimeout'));
 		assert.ok(clearIntSpy.called);
 		done();
 	}, 1000);


### PR DESCRIPTION
This adds a new CustomEvent that enables monitoring when Moat IVT has timed out