### PR TITLE
Add monitoring sampling functionality

### DIFF
--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -452,6 +452,12 @@ export const cookie = function(name) {
 
 export const getVersion = () => version || 'UNKNOWN';
 
+const metricsSampleThreshold = Math.random();
+
+export function inSample(sampleSize) {
+	return typeof sampleSize === 'undefined' || sampleSize < metricsSampleThreshold;
+}
+
 export default {
 	on,
 	off,
@@ -484,5 +490,6 @@ export default {
 	cookie,
 	getVersion,
 	setupMetrics,
+	inSample,
 	perfMark
 };

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -1,3 +1,5 @@
+import utils from './index';
+
 function getMarksForEvents(events, suffix) {
 	const markNames = events.map( eventName => 'oAds.' + eventName + suffix );
 	const performance = window.LUX || window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
@@ -25,10 +27,12 @@ export function setupMetrics(definitions, callback) {
 	}
 
 	definitions.forEach( function(eDef) {
-		const triggers = Array.isArray(eDef.triggers) ? eDef.triggers : [];
-		triggers.forEach(function(trigger) {
-			sendMetricsOnEvent('oAds.' + trigger, eDef, callback);
-		});
+		if (utils.inSample(eDef.sampleSize)) {
+			const triggers = Array.isArray(eDef.triggers) ? eDef.triggers : [];
+			triggers.forEach(function(trigger) {
+				sendMetricsOnEvent('oAds.' + trigger, eDef, callback);
+			});
+		}
 	});
 }
 

--- a/test/qunit/metrics.test.js
+++ b/test/qunit/metrics.test.js
@@ -83,6 +83,7 @@ QUnit.test('the callback is not called if eventDefinitions is not an array', fun
 	}, 0);
 });
 
+
 QUnit.test('any trigger invokes the callback with no timing in the payload', function (assert) {
 	const done = assert.async();
 	this.ads.init();
@@ -116,6 +117,30 @@ QUnit.test('any trigger invokes the callback with no timing in the payload', fun
 	setTimeout( function() {
 		assert.ok(cb.called);
 		assert.ok(cb.calledWith(sinon.match(expectedCbPayload)));
+		done();
+	}, 0);
+});
+
+QUnit.test('a trigger does not call the callback if user not in sample', function (assert) {
+	this.stub(this.utils, 'inSample').returns(false);
+	const done = assert.async();
+	this.ads.init();
+
+	const eventDefinitions = [{
+		spoorAction: 'aaa',
+		triggers: ['bbb', 'ccc'],
+		marks: ['mark1', 'mark2', 'mark3']
+	}];
+
+	const cb = sandbox.stub();
+
+	window.performance = null;
+
+	this.utils.setupMetrics(eventDefinitions, cb);
+	document.dispatchEvent(new CustomEvent('oAds.ccc'));
+
+	setTimeout( function() {
+		assert.notOk(cb.called);
 		done();
 	}, 0);
 });

--- a/test/qunit/utils.test.js
+++ b/test/qunit/utils.test.js
@@ -402,3 +402,19 @@ QUnit.test("getQueryParamByName", function(assert) {
 	assert.equal(this.ads.utils.getQueryParamByName('socialflow', 'http://test.com'), null);
 	assert.equal(this.ads.utils.getQueryParamByName('socialflow', 'http://test.com?socialflow='), '');
 });
+
+QUnit.test("getVersion returns the version number", function(assert) {
+	assert.equal(typeof this.ads.utils.getVersion(), 'string');
+});
+
+QUnit.test("inSample returns true if called with undefined", function(assert) {
+	assert.ok(this.ads.utils.inSample());
+});
+
+QUnit.test("inSample returns the same result when called multiple times with the same sample Size", function(assert) {
+	const sampleSize = 0.5;
+	const firstResult = this.ads.utils.inSample(sampleSize);
+	for (let i = 0; i < 10; i++) {
+		assert.equal(this.ads.utils.inSample(sampleSize), firstResult);
+	}
+});


### PR DESCRIPTION
This enables delegating metrics sampling to `o-ads` by adding a new configuration parameter to the metrics config array. 

It avoids having to replicate the sampling logic on every app that uses the `o-ads` metrics functionality. 

If the `sampleSize` parameter is not specified, `o-ads` will NOT sample and, therefore, will execute the callback every time a "trigger" event is dispatched. 