### PR TITLE
Update Snyk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
       - checkout
       - run: npx occ ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/o-ads
       - run: npm publish --access public
 
 workflows:

--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,4 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.1
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
 ignore: {}
 patch: {}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "release": "release-it",
     "version": "genversion --semi src/js/version.js",
     "obt": "obt",
-    "checksizes": "bundlesize"
+    "checksizes": "bundlesize",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "repository": {
     "type": "git",
@@ -56,7 +57,7 @@
     "pre-git": "^3.17.1",
     "qunitjs": "^1.20.0",
     "release-it": "^7.6.1",
-    "snyk": "^1.149.0",
+    "snyk": "^1.169.1",
     "watchify": "^3.11.0",
     "webpack": "^4.26.1"
   },


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our repos for security reasons. It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building.

See https://github.com/Financial-Times/next/issues/365