### PR TITLE
Temporarily shut off snyk monitor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - checkout
       - run: npx occ ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/o-ads
+      # - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/o-ads
       - run: npm publish --access public
 
 workflows:

--- a/docs/docs/developer-guide/advanced-display.md
+++ b/docs/docs/developer-guide/advanced-display.md
@@ -251,10 +251,11 @@ On top of that `o-ads` is now exposing a new method in the `utils` module called
 
 ### `setupMetrics`
 
-`setupMetrics` accepts two parameters:
+`setupMetrics(eventDefArray, callback, disableSampling)`:
 
-- An array of configuration objects, each of which corresponds to one group of `o-ads` events.
-- A callback that will, potentially, be invoked one or more times for each of those groups. When invoked, the callback will receive an object with information about the timings associated to the events in the groups.
+- `eventDefArray`: An array of configuration objects, each of which corresponds to one group of `o-ads` events.
+- `callback`: A function that will be invoked for each of those groups, possibly multiple times for each. When invoked, the callback will receive an object with information about the timings associated to the events in the group.
+- `disableSampling`: (optional) A boolean indicating if the sampling specified in the `eventDefArray` should be ignored. That is, when set to `true`, no sampling will be applied. It's default value is `false`.
 
 Each of the configuration objects must include the following fields:
 


### PR DESCRIPTION
The recently-added `snyk monitor` task is failing when it runs on the `npm publish` step in CircleCI.

As @taktran has found out, the reason for it seems to be the fact `npm publish` is expecting a `node_modules` to exist from a previous `npm install`. However, we don't seem to be using the `attach workspace` functionality that CircleCI provides in our `.circleci/.config.yml`. 

I cannot fix it quickly without having to spend quite some time learning more about CircleCI, so I've decided to open a new issue for that and mute the problem temporarily.

I am using this same PR to add some missing documentation for the `disableSampling` functionality in the metrics.