### PR TITLE
new slotCollapsed event and added creativeId to metrics

### DIFF
--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -390,6 +390,7 @@ Slot.prototype.fire = function(name, data) {
 		name: this.name || '',
 		pos: this.targeting && this.targeting.pos || '',
 		size: this.gpt && this.gpt.size || '',
+		creativeId: this.gpt && this.gpt.creativeId || '',
 		slot: this
 	};
 

--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -262,6 +262,7 @@ Slots.prototype.initPostMessage = function() {
 
 			// Received message to Collapse ad slot.
 			else if (type === 'collapse') {
+				slot.fire('slotCollapsed');
 				slot.collapse();
 			}
 

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -31,7 +31,9 @@ export function broadcast(eventName, data, target) {
 		detail: data
 	};
 
-	const markName = typeof data === 'object' && 'pos' in data && 'name' in data ? [eventName, data.pos, data.name, data.size.length ? data.size.toString() : ''].join('__') : eventName;
+	const hasDetails = typeof data === 'object' && 'pos' in data && 'name' in data;
+	const size = data && data.size && data.size.length ? data.size.toString() : '';
+	const markName = hasDetails ? [eventName, data.pos, data.name, size].join('__') : eventName;
 	perfMark(markName);
 	target.dispatchEvent(new CustomEvent(eventName, opts));
 }

--- a/test/qunit/slots.post.message.test.js
+++ b/test/qunit/slots.post.message.test.js
@@ -130,6 +130,8 @@ QUnit.test('Post message "collapse" message will call slot.collapse()', function
 	this.stub(this.utils, 'iframeToSlotName', function () {
 		return slotName;
 	});
+	const utils = this.ads.utils;
+	this.spy(utils, 'broadcast');
 
 	document.body.addEventListener('oAds.slotReady', function () {
 		window.postMessage('{ "type": "oAds.collapse", "collapse": true}', '*');
@@ -140,6 +142,7 @@ QUnit.test('Post message "collapse" message will call slot.collapse()', function
 		// defined in slots.js
 		setTimeout(() => {
 			assert.ok(slot.collapse.called, 'the collapse method is called');
+			assert.ok(utils.broadcast.calledWith('slotCollapsed'), 'broadcast is called with "slotCollapsed" as parameter');
 			done();
 		}, 0);
 	});


### PR DESCRIPTION
Added a new event `oAds.slotCollapsed` to detect collapsed slots, since the existing `oAds.collapsed` is triggered in a way that it can't provide all the information we need for using it in metrics.

Added "creativeId" information to performance marks and metrics.

Refactored some difficult-to-read code.