### PR TITLE
Added "isEmpty" attribute from DFP's response to slot metrics

### DIFF
--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -392,7 +392,7 @@ Slot.prototype.fire = function(name, data) {
 		pos: this.targeting && this.targeting.pos || '',
 		size: gpt.size || '',
 		creativeId: gpt.creativeId || '',
-		isEmpty: typeof gpt.isEmpty === 'undefined' ? 'n/a' : `${gpt.isEmpty}`,
+		isEmpty: typeof gpt.isEmpty === 'undefined' ? '' : `${gpt.isEmpty}`,
 		slot: this
 	};
 

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -386,16 +386,17 @@ Slot.prototype.submitImpression = function() {
  *	fire an event on the slot
  */
 Slot.prototype.fire = function(name, data) {
+	const gpt = this.gpt || {};
 	const details = {
 		name: this.name || '',
 		pos: this.targeting && this.targeting.pos || '',
-		size: this.gpt && this.gpt.size || '',
-		creativeId: this.gpt && this.gpt.creativeId || '',
+		size: gpt.size || '',
+		creativeId: gpt.creativeId || '',
+		isEmpty: typeof gpt.isEmpty === 'undefined' ? 'n/a' : `${gpt.isEmpty}`,
 		slot: this
 	};
 
 	if (utils.isPlainObject(data)) {
-		data.pMarkDetails = details;
 		utils.extend(details, data);
 	}
 

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -19,7 +19,7 @@ export const perfMark = name => {
 // the event payload which help identify unequivocally the slot that originated the event
 export function buildPerfmarkSuffix(eventDetailsObj) {
 	let suffix = '';
-	if (eventDetailsObj && 'pos' in eventDetailsObj && 'name' in eventDetailsObj) {
+	if (eventDetailsObj && typeof eventDetailsObj === 'object' && 'pos' in eventDetailsObj && 'name' in eventDetailsObj) {
 		suffix = '__' + [eventDetailsObj.pos, eventDetailsObj.name, eventDetailsObj.size, eventDetailsObj.creativeId].join('__');
 	}
 	return suffix;

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -15,6 +15,16 @@ export const perfMark = name => {
 	}
 };
 
+// Creates a suffix for an event's performance mark based on some of the attributes on
+// the event payload which help identify unequivocally the slot that originated the event
+export function buildPerfmarkSuffix(eventDetailsObj) {
+	let suffix = '';
+	if (eventDetailsObj && 'pos' in eventDetailsObj && 'name' in eventDetailsObj) {
+		suffix = '__' + [eventDetailsObj.pos, eventDetailsObj.name, eventDetailsObj.size, eventDetailsObj.creativeId].join('__');
+	}
+	return suffix;
+}
+
 /**
 * Broadscasts an o-ads event
 * @param {string} name The name of the event
@@ -31,10 +41,15 @@ export function broadcast(eventName, data, target) {
 		detail: data
 	};
 
-	const hasDetails = typeof data === 'object' && 'pos' in data && 'name' in data;
-	const size = data && data.size && data.size.length ? data.size.toString() : '';
-	const creativeId = data && data.creativeId;
-	const markName = hasDetails ? [eventName, data.pos, data.name, size, creativeId].join('__') : eventName;
+	const evDetails = !data ? {} : {
+		pos: data.pos,
+		name: data.name,
+		size: data.size && data.size.length ? data.size.toString() : '',
+		creativeId: data.creativeId
+	};
+
+	const suffix = buildPerfmarkSuffix(evDetails);
+	const markName = eventName + suffix;
 	perfMark(markName);
 	target.dispatchEvent(new CustomEvent(eventName, opts));
 }

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -41,12 +41,13 @@ export function broadcast(eventName, data, target) {
 		detail: data
 	};
 
-	const evDetails = !data ? {} : {
+	const isSlotEvent = typeof data === 'object' && 'pos' in data;
+	const evDetails = isSlotEvent ? {
 		pos: data.pos,
 		name: data.name,
 		size: data.size && data.size.length ? data.size.toString() : '',
 		creativeId: data.creativeId
-	};
+	} : {};
 
 	const suffix = buildPerfmarkSuffix(evDetails);
 	const markName = eventName + suffix;

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -1,4 +1,4 @@
-import { on, off, once, broadcast, perfMark } from './events';
+import { on, off, once, broadcast, perfMark, buildPerfmarkSuffix } from './events';
 import { setupMetrics } from './metrics';
 import messenger from './messenger';
 import responsive, { getCurrent } from './responsive';
@@ -491,5 +491,6 @@ export default {
 	getVersion,
 	setupMetrics,
 	inSample,
-	perfMark
+	perfMark,
+	buildPerfmarkSuffix
 };

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -64,11 +64,7 @@ function sendMetricsOnEvent(eventName, eMarkMap, callback) {
 }
 
 function sendMetrics(eMarkMap, eventDetails, callback) {
-	let suffix = '';
-	if (eventDetails && 'pos' in eventDetails && 'name' in eventDetails) {
-		suffix = '__' + [eventDetails.pos, eventDetails.name, eventDetails.size, eventDetails.creativeId].join('__');
-	}
-
+	const suffix = utils.buildPerfmarkSuffix(eventDetails);
 	const marks = getMarksForEvents(eMarkMap.marks, suffix);
 
 	if (eMarkMap.navigation) {
@@ -87,7 +83,8 @@ function sendMetrics(eMarkMap, eventDetails, callback) {
 			name: eventDetails.name,
 			pos: eventDetails.pos,
 			size: eventDetails.size && eventDetails.size.toString(),
-			creativeId: eventDetails.creativeId && eventDetails.creativeId || 0
+			creativeId: eventDetails.creativeId || 0,
+			isEmpty: `${eventDetails.isEmpty}` || ''
 		};
 	}
 

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -19,6 +19,7 @@ function getMarksForEvents(events, suffix) {
 	return marks;
 }
 
+/* istanbul ignore next */
 function getNavigationPerfMarks(desiredMarks) {
 	if (!performance || !performance.getEntriesByType || !utils.isArray(desiredMarks)) {
 		/* istanbul ignore next  */

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -29,11 +29,7 @@ function getNavigationPerfMarks(desiredMarks) {
 	const navMarks = utils.isArray(navMarksArray) && navMarksArray[0] || {};
 	const marks = {};
 	desiredMarks.forEach(function(markName) {
-		// if the navigation mark is zero, it means we tried to capture it too early
-		// i.e. before the event happened, so it's useless
-		if (navMarks[markName]) {
-			marks[markName] = navMarks[markName];
-		}
+		marks[markName] = typeof navMarks[markName] === 'number' ? Math.round(navMarks[markName]) : 0;
 	});
 	return marks;
 }

--- a/test/qunit/gpt.test.js
+++ b/test/qunit/gpt.test.js
@@ -527,7 +527,7 @@ QUnit.test('define responsive slot', function(assert) {
 	assert.ok(gptSlot.defineSizeMapping.calledOnce, 'the GPT defineSizeMapping slot is called');
 });
 
-QUnit.test('slotRenderStart event fires on slot with the pos, size and name', function(assert) {
+QUnit.test('slotRenderStart event is fired with the correct slot name', function(assert) {
 	const done = assert.async();
 	const html = '<div data-o-ads-name="rendered-test" data-o-ads-formats="MediumRectangle" data-o-ads-targeting="pos=mid"></div>';
 	this.fixturesContainer.add(html);
@@ -535,10 +535,6 @@ QUnit.test('slotRenderStart event fires on slot with the pos, size and name', fu
 
 	document.body.addEventListener('oAds.slotRenderStart', function(event) {
 		assert.equal(event.detail.name, 'rendered-test', 'our test slot fired the slotRenderStart event');
-		assert.equal(event.detail.pMarkDetails.name, 'rendered-test', 'the name attribute is set correctly in the performance mark details');
-		assert.equal(event.detail.pMarkDetails.pos, 'mid', 'the pos attribute is set correctly in the performance mark details');
-		assert.equal(event.detail.pMarkDetails.size, '300,250', 'the size attribute is set correctly in the performance mark details');
-		assert.ok(event.detail.pMarkDetails.slot, 'the slot object is available in the performance mark details');
 		done();
 	});
 

--- a/test/qunit/utils.test.js
+++ b/test/qunit/utils.test.js
@@ -442,12 +442,3 @@ QUnit.test("buildPerfmarkSuffix returns a suffix containing pos, name, size and 
 	};
 	assert.equal(this.ads.utils.buildPerfmarkSuffix(incompleteEvDetails), '__pos__name____');
 });
-
-
-
-
-
-
-
-
-

--- a/test/qunit/utils.test.js
+++ b/test/qunit/utils.test.js
@@ -418,3 +418,36 @@ QUnit.test("inSample returns the same result when called multiple times with the
 		assert.equal(this.ads.utils.inSample(sampleSize), firstResult);
 	}
 });
+
+QUnit.test("buildPerfmarkSuffix returns an empty string if the argument is not an object with a 'pos' and 'name' property", function(assert) {
+	assert.equal(this.ads.utils.buildPerfmarkSuffix(), '');
+	assert.equal(this.ads.utils.buildPerfmarkSuffix({a: 'b'}), '');
+	assert.equal(this.ads.utils.buildPerfmarkSuffix({pos: 'pos'}), '');
+	assert.equal(this.ads.utils.buildPerfmarkSuffix({name: 'name'}), '');
+	assert.equal(this.ads.utils.buildPerfmarkSuffix('something'), '');
+});
+
+QUnit.test("buildPerfmarkSuffix returns a suffix containing pos, name, size and creativeId", function(assert) {
+	const eventDetails = {
+		pos: 'pos',
+		name: 'name',
+		size: '300x250',
+		creativeId: '12312301283'
+	};
+	assert.equal(this.ads.utils.buildPerfmarkSuffix(eventDetails), '__pos__name__300x250__12312301283');
+
+	const incompleteEvDetails = {
+		pos: 'pos',
+		name: 'name'
+	};
+	assert.equal(this.ads.utils.buildPerfmarkSuffix(incompleteEvDetails), '__pos__name____');
+});
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This adds the value of gpt's `isEmpty` attribute to any `slot` metrics where it's available (mostly useful in `slot-rendered`).