### PR TITLE
Attempt to fix broken release task

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,9 @@
     "node": "^8.6.0"
   },
   "release": {
+    "github": {
+      "release": true
+    },
     "analyzeCommits": "simple-commit-message"
   },
   "bundlesize": [


### PR DESCRIPTION
The `release` task in `package.json` seems to fail on the very last step because it. I believe it has to do with a change in the `release-it` package that I hope this PR will fix.