### PR TITLE
Adapted release-it config to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
       - checkout
       - run: npx occ ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
+      - run: npm install
       - run: npx snyk monitor --org=financial-times --project-name=Financial-Times/o-ads
       - run: npm publish --access public
 

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "npm run version && git add src/js/version.js",
-  "src": {
+  "git": {
     "tagName": "v%s",
     "commit": true,
     "tag": true,

--- a/package.json
+++ b/package.json
@@ -84,9 +84,6 @@
     "node": "^8.6.0"
   },
   "release": {
-    "github": {
-      "release": true
-    },
     "analyzeCommits": "simple-commit-message"
   },
   "bundlesize": [


### PR DESCRIPTION
A change was needed in `release-it.json` after upgrading to the latest version, this was preventing the GitHub release from using the label that the CircleCI config was expecting to kick off publishing to npm.