### PR TITLE
Added new clearPerfMarks method to metrics utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "bundlesize": [
     {
       "path": "./build/main.js",
-      "maxSize": "116 kB"
+      "maxSize": "117 kB"
     }
   ]
 }

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -1,5 +1,5 @@
 import { on, off, once, broadcast, perfMark, buildPerfmarkSuffix } from './events';
-import { setupMetrics } from './metrics';
+import { setupMetrics, clearPerfMarks } from './metrics';
 import messenger from './messenger';
 import responsive, { getCurrent } from './responsive';
 import log, { isOn, start, end, info, warn, error, table, attributeTable} from './log';
@@ -490,6 +490,7 @@ export default {
 	cookie,
 	getVersion,
 	setupMetrics,
+	clearPerfMarks,
 	inSample,
 	perfMark,
 	buildPerfmarkSuffix

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -24,14 +24,12 @@ export function clearPerfMarks(metricsDefinitions, groupsToClear) {
 		return;
 	}
 
-	const eventsToClear = groupsToClear.reduce(
-		(prevList, groupName) => {
-			const group = metricsDefinitions.find(g => g.spoorAction === groupName);
-			if (!group) {
-				return prevList;
-			}
-			return prevList.concat(group.marks);
-		}, []);
+	const relevantGroups = metricsDefinitions.filter( group =>
+		groupsToClear.includes(group.spoorAction)
+	);
+	const relevantGroupsMarks = relevantGroups.map( group => group.marks );
+	// Because relevantGroupsMarks is a 2D array ...
+	const eventsToClear = [].concat(...relevantGroupsMarks);
 
 	const perfMarks = performance.getEntriesByType('mark');
 

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -19,6 +19,31 @@ function getMarksForEvents(events, suffix) {
 	return marks;
 }
 
+export function clearPerfMarks(metricsDefinitions, groupsToClear) {
+	if (!performance || !performance.getEntriesByType) {
+		return;
+	}
+
+	const eventsToClear = groupsToClear.reduce(
+		(prevList, groupName) => {
+			const group = metricsDefinitions.find(g => g.spoorAction === groupName);
+			if (!group) {
+				return prevList;
+			}
+			return prevList.concat(group.marks);
+		}, []);
+
+	const perfMarks = performance.getEntriesByType('mark');
+
+	perfMarks.forEach( ({name}) => {
+		eventsToClear.forEach( eventName => {
+			if (name.match(`oAds.${eventName}`)) {
+				performance.clearMarks(name);
+			}
+		});
+	});
+}
+
 /* istanbul ignore next */
 function getNavigationPerfMarks(desiredMarks) {
 	if (!performance || !performance.getEntriesByType || !utils.isArray(desiredMarks)) {

--- a/test/qunit/metrics.test.js
+++ b/test/qunit/metrics.test.js
@@ -247,7 +247,7 @@ QUnit.test('collects performance marks using the properties in the event payload
 	}, 0);
 });
 
-QUnit.only('utils.clearPerfMarks clears the expected events', function(assert) {
+QUnit.test('utils.clearPerfMarks clears the expected events', function(assert) {
 	const metricsDefinitions = [
 		{
 			spoorAction: 'group1',
@@ -267,7 +267,7 @@ QUnit.only('utils.clearPerfMarks clears the expected events', function(assert) {
 
 	const perfMarksBefore = ['oAds.first', 'oAds.second', 'oAds.third', 'oAds.second-blah',
 		'oAds.fourth', 'oAds.fifth', 'oAds.fifthblabla', 'oAds.seventh',
-		'oAds.eighth', 'oAds.eighthbla', 'aa'];
+		'oAds.eighth', 'oAds.eighthbla'];
 
 	perfMarksBefore.forEach( (markName) => {
 		performance.mark(markName);
@@ -279,9 +279,6 @@ QUnit.only('utils.clearPerfMarks clears the expected events', function(assert) {
 
 	this.utils.clearPerfMarks(metricsDefinitions, groupsToClear);
 	const afterMarks = performance.getEntriesByType('mark').map( m => m.name );
-
-	console.log('-----------------------------------');
-	console.log('afterMarks', afterMarks);
 
 	expectedMarksAfter.forEach( markName => {
 		assert.ok(afterMarks.includes(markName));

--- a/test/qunit/metrics.test.js
+++ b/test/qunit/metrics.test.js
@@ -247,3 +247,47 @@ QUnit.test('collects performance marks using the properties in the event payload
 	}, 0);
 });
 
+QUnit.only('utils.clearPerfMarks clears the expected events', function(assert) {
+	const metricsDefinitions = [
+		{
+			spoorAction: 'group1',
+			marks: ['first', 'second', 'third']
+		},
+		{
+			spoorAction: 'group2',
+			marks: ['fourth', 'fifth', 'sixth']
+		},
+		{
+			spoorAction: 'group3',
+			marks: ['seventh', 'eighth', 'ninth']
+		}
+	];
+
+	const groupsToClear = ['group1', 'group3'];
+
+	const perfMarksBefore = ['oAds.first', 'oAds.second', 'oAds.third', 'oAds.second-blah',
+		'oAds.fourth', 'oAds.fifth', 'oAds.fifthblabla', 'oAds.seventh',
+		'oAds.eighth', 'oAds.eighthbla', 'aa'];
+
+	perfMarksBefore.forEach( (markName) => {
+		performance.mark(markName);
+	});
+
+	const expectedMarksAfter = [ 'oAds.fourth', 'oAds.fifth', 'oAds.fifthblabla'];
+	const notExpectedMarksAfter = ['oAds.first', 'oAds.second', 'oAds.third', 'oAds.second-blah',
+		'oAds.seventh', 'oAds.eighth', 'oAds.eighthbla'];
+
+	this.utils.clearPerfMarks(metricsDefinitions, groupsToClear);
+	const afterMarks = performance.getEntriesByType('mark').map( m => m.name );
+
+	console.log('-----------------------------------');
+	console.log('afterMarks', afterMarks);
+
+	expectedMarksAfter.forEach( markName => {
+		assert.ok(afterMarks.includes(markName));
+	});
+
+	notExpectedMarksAfter.forEach( markName => {
+		assert.notOk(afterMarks.includes(markName));
+	});
+});


### PR DESCRIPTION
This adds a new public method in `utils.clearPerfMarks` that allows to clear existing performance marks for certain event groups based on an existing metrics definitions array.

This allows removing performance marks for previously visited pages in environments where internal navigation is supported, like a web-app. 