### PR TITLE
Run npm install before running occ upon publishing to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,9 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
+      - run: npm install
       - run: npx occ ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
-      - run: npm install
       - run: npx snyk monitor --org=financial-times --project-name=Financial-Times/o-ads
       - run: npm publish --access public
 


### PR DESCRIPTION
The current `publish-to-npm` task in CircleCI [is broken](https://circleci.com/gh/Financial-Times/o-ads/2457)