### PR TITLE
Add page change logic

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -11,6 +11,7 @@ export const perfMark = name => {
 	/* istanbul ignore next */
 	const performance = window.LUX || window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
 	if (performance && performance.mark) {
+		performance.clearMarks(name);
 		performance.mark(name);
 	}
 };

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -1,5 +1,5 @@
 import { on, off, once, broadcast, perfMark, buildPerfmarkSuffix } from './events';
-import { setupMetrics, clearPerfMarks } from './metrics';
+import { setupMetrics, clearPerfMarks, markPageChange } from './metrics';
 import messenger from './messenger';
 import responsive, { getCurrent } from './responsive';
 import log, { isOn, start, end, info, warn, error, table, attributeTable} from './log';
@@ -491,6 +491,7 @@ export default {
 	getVersion,
 	setupMetrics,
 	clearPerfMarks,
+	markPageChange,
 	inSample,
 	perfMark,
 	buildPerfmarkSuffix

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -114,3 +114,7 @@ function sendMetrics(eMarkMap, eventDetails, callback) {
 	callback(eventPayload);
 }
 
+export function markPageChange(definitions, groupsToClear) {
+	clearPerfMarks(definitions, groupsToClear);
+	utils.perfMark('oAds.pageChange');
+}


### PR DESCRIPTION
This adds a new `markPageChange` that enables creating performance marks for page navigation events and can clears old performance marks for previously visited pages.