### PR TITLE
Fix pageChange event not being triggered

### DIFF
--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -116,5 +116,5 @@ function sendMetrics(eMarkMap, eventDetails, callback) {
 
 export function markPageChange(definitions, groupsToClear) {
 	clearPerfMarks(definitions, groupsToClear);
-	utils.perfMark('oAds.pageChange');
+	utils.broadcast('pageChange');
 }


### PR DESCRIPTION
This fixes the 'pageChange' event not being triggered, which makes it impossible to send metrics based on page changes 