### PR TITLE
ADSDEV-95 Fix page change not being picked

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,5 +7,4 @@ nightwatch.conf.local.js
 build/
 node_modules
 o-ads-compiled.js
-test/jest
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,13 +1,21 @@
 // babel.config.js
-module.exports = {
-	presets: [
-		[
-			'@babel/preset-env',
-			{
-				targets: {
-					node: 'current',
+module.exports = api => {
+	const config = {
+		presets: [
+			[
+				'@babel/preset-env',
+				{
+					targets: {
+						node: 'current',
+					},
 				},
-			},
+			],
 		],
-	],
+	};
+
+	if (api.env('test')) {
+		config.plugins = ['babel-plugin-rewire'];
+	}
+
+	return config;
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -150,9 +150,9 @@ module.exports = {
 	],
 
 	// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-	// testPathIgnorePatterns: [
-	//   "/node_modules/"
-	// ],
+	testPathIgnorePatterns: [
+		"/node_modules/", "/jest/testUtils"
+	],
 
 	// The regexp pattern or array of patterns that Jest uses to detect test files
 	// testRegex: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -2787,6 +2787,12 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-plugin-rewire": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-rewire/-/babel-plugin-rewire-1.2.0.tgz",
+      "integrity": "sha512-JBZxczHw3tScS+djy6JPLMjblchGhLI89ep15H3SyjujIzlxo5nr6Yjo7AXotdeVczeBmWs0tF8PgJWDdgzAkQ==",
+      "dev": true
+    },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   "bundlesize": [
     {
       "path": "./build/main.js",
-      "maxSize": "117 kB"
+      "maxSize": "118 kB"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@cypress/webpack-preprocessor": "^2.0.0",
     "@financial-times/secret-squirrel": "^2.12.4",
     "babel-jest": "^24.8.0",
+    "babel-plugin-rewire": "^1.2.0",
     "bower-resolve-webpack-plugin": "^1.0.5",
     "browserstack-local": "^1.3.5",
     "bundlesize": "^0.18.0",

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -14,17 +14,16 @@ function getMarksForEvents(events, suffix) {
 		if (pMarks && pMarks.length) {
 			// We don't need sub-millisecond precision
 			marks[markName] = Math.round(pMarks[0].startTime);
-		} else if (suffix) {
-			// Even if the suffix parameter is not null, the mark name we care about
-			// can be a generic one, in which case we need to look for the
-			// bare mark name
-			const findMarkNameNoSuffix = markName.match(`(.*)${suffix}$`);
-			const markNameWithoutSuffix = findMarkNameNoSuffix && findMarkNameNoSuffix[1];
-			if (markNameWithoutSuffix) {
-				const pMarks2 = performance.getEntriesByName(markNameWithoutSuffix);
-				if (pMarks2 && pMarks2.length) {
-					marks[markName] = Math.round(pMarks2[0].startTime);
-				}
+			return;
+		}
+
+		// If no mark has been found, we might be looking for a page-level
+		// mark name, i.e. one without a suffix
+		if (suffix) {
+			const mNameNoSuffix = mName.replace(suffix, '');
+			const pMarks2 = performance.getEntriesByName(mNameNoSuffix);
+			if (pMarks2 && pMarks2.length) {
+				marks[markName] = Math.round(pMarks2[0].startTime);
 			}
 		}
 	});

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -14,6 +14,18 @@ function getMarksForEvents(events, suffix) {
 		if (pMarks && pMarks.length) {
 			// We don't need sub-millisecond precision
 			marks[markName] = Math.round(pMarks[0].startTime);
+		} else if (suffix) {
+			// Even if the suffix parameter is not null, the mark name we care about
+			// can be a generic one, in which case we need to look for the
+			// bare mark name
+			const findMarkNameNoSuffix = markName.match(`(.*)${suffix}$`);
+			const markNameWithoutSuffix = findMarkNameNoSuffix && findMarkNameNoSuffix[1];
+			if (markNameWithoutSuffix) {
+				const pMarks2 = performance.getEntriesByName(markNameWithoutSuffix);
+				if (pMarks2 && pMarks2.length) {
+					marks[markName] = Math.round(pMarks2[0].startTime);
+				}
+			}
 		}
 	});
 	return marks;

--- a/test/jest/.eslintrc.json
+++ b/test/jest/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "jest/globals": true
+  },
   "rules": {
     "jest/no-disabled-tests": "error",
     "jest/no-focused-tests": "error",

--- a/test/jest/.eslintrc.json
+++ b/test/jest/.eslintrc.json
@@ -11,6 +11,6 @@
   },
   "plugins": ["jest"],
   "globals": {
-    "expect": true
+    "expect": false
   }
 }

--- a/test/jest/.eslintrc.json
+++ b/test/jest/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "env": {
+    "jest": true,
     "jest/globals": true
   },
   "rules": {
@@ -9,8 +10,5 @@
     "jest/prefer-to-have-length": "warn",
     "jest/valid-expect": "error"
   },
-  "plugins": ["jest"],
-  "globals": {
-    "expect": false
-  }
+  "plugins": ["jest"]
 }

--- a/test/jest/metrics.js
+++ b/test/jest/metrics.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 import {setupMetrics, __RewireAPI__ } from '../../src/js/utils/metrics.js';
 import { mark, getEntriesByName } from './testUtils/pMark.js';
 

--- a/test/jest/metrics.js
+++ b/test/jest/metrics.js
@@ -1,5 +1,27 @@
-import {setupMetrics} from '../../src/js/utils/metrics.js';
+import {setupMetrics, __RewireAPI__ } from '../../src/js/utils/metrics.js';
+import { mark, getEntriesByType } from './pMark.js'
 
 test('metrics to export a "setupMetrics" function', () => {
 	expect(setupMetrics).toBeDefined();
+});
+
+test('getMarksForEvents', () => {
+	const getMarksForEvents = __RewireAPI__.__get__('getMarksForEvents');
+	expect(getMarksForEvents).toBeDefined();
+	window.performance.mark = jest.fn(mark);
+	window.performance.getEntriesByType = jest.fn(getEntriesByType);
+
+	window.performance.mark('a__suffix__');
+	window.performance.mark('b__suffix__');
+	window.performance.mark('c__suffix__');
+	window.performance.mark('d');
+
+	const events = [
+		{
+			marks: ['a', 'b', 'c', 'd']
+		}
+	];
+
+	const marks = getMarksForEvents(events, '__suffix__');
+	expect(marks).toBeDefined();
 });

--- a/test/jest/metrics.js
+++ b/test/jest/metrics.js
@@ -1,5 +1,5 @@
 import {setupMetrics, __RewireAPI__ } from '../../src/js/utils/metrics.js';
-import { mark, getEntriesByType } from './pMark.js'
+import { mark, getEntriesByName } from './testUtils/pMark.js';
 
 test('metrics to export a "setupMetrics" function', () => {
 	expect(setupMetrics).toBeDefined();
@@ -9,19 +9,18 @@ test('getMarksForEvents', () => {
 	const getMarksForEvents = __RewireAPI__.__get__('getMarksForEvents');
 	expect(getMarksForEvents).toBeDefined();
 	window.performance.mark = jest.fn(mark);
-	window.performance.getEntriesByType = jest.fn(getEntriesByType);
+	window.performance.getEntriesByName = jest.fn(getEntriesByName);
 
-	window.performance.mark('a__suffix__');
-	window.performance.mark('b__suffix__');
-	window.performance.mark('c__suffix__');
-	window.performance.mark('d');
+	window.performance.mark('oAds.a__suffix__');
+	window.performance.mark('oAds.b__suffix__');
+	window.performance.mark('oAds.c__suffix__');
+	window.performance.mark('oAds.d');
 
-	const events = [
-		{
-			marks: ['a', 'b', 'c', 'd']
-		}
-	];
+	const events = ['a', 'b', 'c', 'd'];
 
 	const marks = getMarksForEvents(events, '__suffix__');
-	expect(marks).toBeDefined();
+	expect(marks).toHaveProperty('a');
+	expect(marks).toHaveProperty('b');
+	expect(marks).toHaveProperty('c');
+	expect(marks).toHaveProperty('d');
 });

--- a/test/jest/pMark.js
+++ b/test/jest/pMark.js
@@ -1,0 +1,17 @@
+const perfmarks = [];
+
+export const mark = markName => {
+	perfmarks.push({
+		type: 'mark',
+		name: markName,
+		startTime: (new Date()).getMilliseconds()
+	});
+};
+
+export const getEntriesByType = type => {
+	const marks = perfmarks.filter( m => m.type === type );
+	return marks;
+};
+
+
+

--- a/test/jest/testUtils/pMark.js
+++ b/test/jest/testUtils/pMark.js
@@ -13,5 +13,7 @@ export const getEntriesByType = type => {
 	return marks;
 };
 
-
-
+export const getEntriesByName = name => {
+	const marks = perfmarks.filter( m => m.name === name );
+	return marks;
+};


### PR DESCRIPTION
Page-level events, i.e. the ones fired with `utils.broadcast` unlike the ones fired via `slot.fire`, create a performance mark that doesn't contain a suffix in its name. 

However, those performance marks might be needed in a group that expects a suffix (e.g. the ones triggered by `slotGoRender` or `slotRenderEnded`).

This fixes a bug in which page-level marks are not being picked by slot-triggered actions.