### PR TITLE
Enable class injection based on the new o-ads-embed postMessage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6990,6 +6990,12 @@
       "integrity": "sha512-V89BUiwf76FHlhj1mlNhNyvpzTy8VbWCh2RZpKYz/XDSl/pcuwFiE/LMt7r3q1sRKygzEMjbYeDob8MMuvakXg==",
       "dev": true
     },
+    "eslint-plugin-qunit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-4.0.0.tgz",
+      "integrity": "sha512-+0i2xcYryUoLawi47Lp0iJKzkP931G5GXwIOq1KBKQc2pknV1VPjfE6b4mI2mR2RnL7WRoS30YjwC9SjQgJDXQ==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -741,6 +741,23 @@
         "semver": "^5.5.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -1444,6 +1461,50 @@
       "dev": true,
       "requires": {
         "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.1.0.tgz",
+      "integrity": "sha512-cKAONDmJKGJ2DSu6R/+lgA8i8uyZIx4CaOiiK0yMjp+2UecH6kfjunJiy5hfExKMtR74eyzFriqO1w9aTC8VyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.1",
+        "chalk": "^2.4.1",
+        "css": "^2.2.3",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^24.0.0",
+        "jest-matcher-utils": "^24.0.0",
+        "lodash": "^4.17.11",
+        "pretty-format": "^24.0.0",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "redent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+          "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^4.0.0",
+            "strip-indent": "^3.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.0"
+          }
+        }
       }
     },
     "@types/agent-base": {
@@ -5389,6 +5450,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.3.0.tgz",
       "integrity": "sha1-XxrUPi2O77/cME/NOaUhZklD4+s=",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssnano": {
@@ -12973,6 +13040,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
       "dev": true
     },
     "minimalistic-assert": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "dotenv": "^8.0.0",
     "eslint": "^6.0.1",
     "eslint-plugin-jest": "^22.7.1",
+    "eslint-plugin-qunit": "^4.0.0",
     "fetch-mock": "^5.1.1",
     "geckodriver": "^1.16.1",
     "genversion": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/preset-env": "^7.4.5",
     "@cypress/webpack-preprocessor": "^2.0.0",
     "@financial-times/secret-squirrel": "^2.12.4",
+    "@testing-library/jest-dom": "^4.1.0",
     "babel-jest": "^24.8.0",
     "babel-plugin-rewire": "^1.2.0",
     "bower-resolve-webpack-plugin": "^1.0.5",

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -331,6 +331,16 @@ Slot.prototype.collapse = function() {
 };
 
 /**
+ * add the additional class to th slot
+ */
+Slot.prototype.addClass = function(className) {
+	// this.setFormatLoaded(false);
+	document.body.classList.add(`o-ads-${className}`);
+	utils.broadcast('slotClassAdded', this);
+	return this;
+};
+
+/**
  * sets a classname of the format
  */
 Slot.prototype.setFormatLoaded = function(format) {

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -335,7 +335,7 @@ Slot.prototype.collapse = function() {
  */
 Slot.prototype.addClass = function(className) {
 	this.container.classList.add(`o-ads-${className}`);
-	// utils.broadcast('slotClassAdded', this);
+	utils.broadcast('slotClassAdded', this);
 	return this;
 };
 

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -334,9 +334,8 @@ Slot.prototype.collapse = function() {
  * add the additional class to th slot
  */
 Slot.prototype.addClass = function(className) {
-	// this.setFormatLoaded(false);
-	document.body.classList.add(`o-ads-${className}`);
-	utils.broadcast('slotClassAdded', this);
+	this.container.classList.add(`o-ads-${className}`);
+	// utils.broadcast('slotClassAdded', this);
 	return this;
 };
 

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -331,7 +331,7 @@ Slot.prototype.collapse = function() {
 };
 
 /**
- * add the additional class to th slot
+ * add the additional class to the slot
  */
 Slot.prototype.addClass = function(className) {
 	this.container.classList.add(`o-ads-${className}`);

--- a/src/js/slots.js
+++ b/src/js/slots.js
@@ -260,6 +260,10 @@ Slots.prototype.initPostMessage = function() {
 				slot.fire('slotRenderEnded');
 			}
 
+			else if(type === 'slotClass' && data.slotClass) {
+				slot.addClass(data.slotClass);
+			}
+
 			// Received message to Collapse ad slot.
 			else if (type === 'collapse') {
 				slot.fire('slotCollapsed');

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,18 +1,22 @@
 {
-  "parserOptions": {
-    "ecmaVersion": 6
-  },
-  "rules": {
-    "no-console": 0,
-    "no-unused-expressions": 0,
-    "no-empty-function": 0,
-    "no-prototype-builtins": 0
-  },
-  "globals": {
-    "context": false,
-    "beforeEach": false,
-    "before": false,
-    "afterEach": false,
-    "after": false
-  }
+	"parserOptions": {
+		"ecmaVersion": 6
+	},
+	"plugins": [
+		"qunit"
+	],
+	"rules": {
+		"qunit/no-only": "error",
+		"no-console": 0,
+		"no-unused-expressions": 0,
+		"no-empty-function": 0,
+		"no-prototype-builtins": 0
+	},
+	"globals": {
+		"context": false,
+		"beforeEach": false,
+		"before": false,
+		"afterEach": false,
+		"after": false
+	}
 }

--- a/test/jest/slot.js
+++ b/test/jest/slot.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+
+import '@testing-library/jest-dom/extend-expect';
+import Slot from '../../src/js/slot.js';
+
+test('slot to export a "Slot" object', () => {
+	expect(Slot).toBeDefined();
+});
+
+test('slot.addClass adds a class to the slot container', (done) => {
+	  document.body.innerHTML = '<div class="container"></div>';
+
+	const container = document.querySelector('.container');
+	const newSlot = new Slot(container);
+	newSlot.addClass('sticky');
+
+	setTimeout( () => {
+		expect(container).toHaveClass('o-ads-sticky');
+		done();
+	}, 0);
+});
+

--- a/test/qunit/slots.post.message.test.js
+++ b/test/qunit/slots.post.message.test.js
@@ -152,6 +152,35 @@ QUnit.test('Post message "collapse" message will call slot.collapse()', function
 	this.spy(slot, 'collapse');
 });
 
+QUnit.only('Post message "slotClass" message will call slot.addClass()', function (assert) {
+	const done = assert.async();
+	const slotName = 'class-added-ad';
+	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');
+	this.stub(this.utils, 'iframeToSlotName', function () {
+		return slotName;
+	});
+	const utils = this.ads.utils;
+	this.spy(utils, 'broadcast');
+
+	document.body.addEventListener('oAds.slotReady', function () {
+		window.postMessage('{ "type": "oAds.slotClass", "slotClass": "sticky"}', '*');
+	});
+
+	window.addEventListener('message', function () {
+		// Make sure this executes AFTER the other 'message' event listener
+		// defined in slots.js
+		setTimeout(() => {
+			assert.ok(slot.addClass.called, 'the addClass method is called');
+			assert.ok(utils.broadcast.calledWith('slotClassAdded'), 'broadcast is called with "slotClassAdded" as parameter');
+			done();
+		}, 0);
+	});
+
+	this.ads.init();
+	const slot = this.ads.slots.initSlot(container);
+	this.spy(slot, 'addClass');
+});
+
 QUnit.test('Unknown postMessage will log an error', function (assert) {
 	const done = assert.async();
 	const slotName = 'test-ad';

--- a/test/qunit/slots.post.message.test.js
+++ b/test/qunit/slots.post.message.test.js
@@ -152,7 +152,7 @@ QUnit.test('Post message "collapse" message will call slot.collapse()', function
 	this.spy(slot, 'collapse');
 });
 
-QUnit.only('Post message "slotClass" message will call slot.addClass()', function (assert) {
+QUnit.test('Post message "slotClass" message will call slot.addClass()', function (assert) {
 	const done = assert.async();
 	const slotName = 'class-added-ad';
 	const container = this.fixturesContainer.add('<div data-o-ads-name="' + slotName + '" data-o-ads-formats="MediumRectangle"></div>');


### PR DESCRIPTION
This change makes `o-ads` react to a postMessage with a property `type` set to `oAds.slotClass` and a `slotClass` property set to an arbitrary value by adding a new class `data-o-ads-{arbitrary value}` to the slot container