### PR TITLE
New link for DFP / Google Ad Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # oAds [![CircleCI Status](https://circleci.com/gh/Financial-Times/o-ads.svg?style=shield&circle-token=36a37c6ca27a08408c2575c7834f5f6f5c5c9d21)](https://circleci.com/gh/Financial-Times/o-ads/tree/master)
 
-This is an Origami module that enables advertising from [Google's DFP Ad server](http://www.google.com/dfp), and provides customised demographic, behavioural (via [Krux](http://www.krux.com/)), and contextual (via [Admantx](http://admantx.com/)) targeting.
+This is an Origami module that enables advertising from [Google's DFP Ad Server (part of Ad Manager)](https://support.google.com/admanager/answer/6022000?hl=en), and provides customised demographic, behavioural (via [Krux](http://www.krux.com/)), and contextual (via [Admantx](http://admantx.com/)) targeting.
 
 ## Requirements
-For basic use, a DFP account with Google is required.
+For basic use, a DFP (DoubleClick for Publishers) account with Google is required.
 Each targeting/tracking supplier will require their own configuration and setup.
 
 ## Demos

--- a/docs/docs/developer-guide/index.md
+++ b/docs/docs/developer-guide/index.md
@@ -7,7 +7,7 @@ section: building
 The delivery of FT Adverts is facilitated by a range of libraries, APIs and third party products:
 
 ### DFP
-[DFP](https://www.google.com/dfp) (DoubleClick for Publishers) is our primary ad server. It is used to traffic and orchestrate which ads get served where and to whom. It is primarily managed by the AdOps team. Within DFP, adverts are referred to as 'creatives' or 'line items' and have respective ids, which are useful for debugging.
+[DFP (part of Google Ad Manager)](https://support.google.com/admanager/answer/6022000?hl=en) (DoubleClick for Publishers) is our primary ad server. It is used to traffic and orchestrate which ads get served where and to whom. It is primarily managed by the AdOps team. Within DFP, adverts are referred to as 'creatives' or 'line items' and have respective ids, which are useful for debugging.
 
 ### o-ads & GPT
 


### PR DESCRIPTION
### Description
The links to the Google DFP (https://www.google.com/dfp) are erroring (https://www.google.com/intl/en_GB/dfp/info/welcome.html#error=no_adsense). Do you need an adsense account to view this link? Or is it just a broken link?

Either way perhaps this should be a public. Had a look and it seems to me a bit like Google have moved away from the 'Doubleclick for Publishers' product name and it's been wrapped up into Google Ad Manager (https://www.ezoic.com/what-is-google-ad-manager-what-happened-to-adx-adsense-dfp/). 

This PR adds what seemed to me like a good intro link but perhaps the team has a better alternative? https://support.google.com/admanager/answer/6022000?hl=en

Suggestions?