### PR TITLE
Stringify all values passed in to GPT targeting

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -103,7 +103,8 @@ function setPageTargeting(targetingData) {
 		googletag.cmd.push(() => {
 			const pubads = googletag.pubads();
 			Object.keys(targetingData).forEach(key => {
-				pubads.setTargeting(key, targetingData[key]);
+				// Convert to string as boolean values are invalid arguments for GPT setTargeting()
+				pubads.setTargeting(key, String(targetingData[key]));
 			});
 		});
 	} else {


### PR DESCRIPTION
### Issue:
`next-ads-api` returns a boolean value for the `'loggedInStatus'`:
```
{
"name": "loggedInStatus",
"key": "loggedIn",
"value": true
}
```

This generates a silent error when setting the GPT targeting info here in `o-ads`:
![image](https://user-images.githubusercontent.com/35195024/65340690-ad5be880-dbc6-11e9-9846-3ddc22e93f91.png)

Discussed with the team / stakeholders and agreed to remove the `loggedIn` value from the api as it's not used by the campaign management team however it is used by some other services e.g. https://github.com/Financial-Times/ft-creative-ss3/blob/d18b6fba5f4eb598bff3737afd0b06b70ab64bf8/themes/base/src/js/module/oPermutive.js#L15. Removing the value from the `next-ads-api` would break this dependency. 

### Fix:
Ensure that all values that are set as targeting with GPT are strings and thus correctly added to the URL. 

#### Ticket - https://jira.ft.com/browse/ADSDEV-64

### Notes:
* I considered an if statement / ternary to check if the value is already a string but felt that this implementation was the most simple _tiny_ bit of javascript. 
* Thought about alternative ways to convert a value safely to a string (`+ ''`, `JSON.stringify()`, `toString()`, but considering the slim chance of any type of value `String()` felt like the winner as none throw an error: 
```
String(string); // 'hello'
String(number); // '1'
String(boolean); // 'true'
String(array); // '1,2,3'
String(object); // '[object Object]'
String(symbolValue); // 'Symbol(123)'
String(undefinedValue); // 'undefined'
String(nullValue); // 'null'
```  

Before this PR `loggedIn` is missing from the GPT targeting values:
![Before Stringify Targeting Value](https://user-images.githubusercontent.com/35195024/65341356-1728c200-dbc8-11e9-9d0a-fe1fb14677e4.png)

After this PR `loggedIn` is now present in the GPT targeting values: 
![After Stringify Targeting Value](https://user-images.githubusercontent.com/35195024/65341357-198b1c00-dbc8-11e9-8ad0-148c126e6120.png)

### Tests
* No new tests added for this as the `loggedIn` value is not used by stakeholders did not feel it warranted additional tests. 
* All current tests still passing. 