### PR TITLE
Added CSS rule to counter GPT broken CSS

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -66,8 +66,8 @@ $o-ads-is-silent: true !default;
 
   // HACK: This is necessary to overcome an issue introducedy by GPT that misplaces ads
   // See: https://ads.google.com/status#hl=en&v=issue&sid=24&iid=6790def915d959f61f56fb7005cba2cc
-  // sass-lint:disable-next-line no-qualifying-elements
-  div[id^='google_ads_iframe_'] {
+
+  div[id^='google_ads_iframe_'] { // sass-lint:disable-line no-qualifying-elements
     margin: 0 auto;
   }
 

--- a/main.scss
+++ b/main.scss
@@ -64,5 +64,11 @@ $o-ads-is-silent: true !default;
 		@include oAdsResponsiveReserve();
 	}
 
+  // HACK: This is necessary to overcome an issue introducedy by GPT that misplaces ads
+  // See: https://ads.google.com/status#hl=en&v=issue&sid=24&iid=6790def915d959f61f56fb7005cba2cc
+   div[id^='google_ads_iframe_'] {
+    margin: 0 auto;
+  }
+
 	$o-ads-is-silent: true !global;
 }

--- a/main.scss
+++ b/main.scss
@@ -66,7 +66,8 @@ $o-ads-is-silent: true !default;
 
   // HACK: This is necessary to overcome an issue introducedy by GPT that misplaces ads
   // See: https://ads.google.com/status#hl=en&v=issue&sid=24&iid=6790def915d959f61f56fb7005cba2cc
-   div[id^='google_ads_iframe_'] {
+  // sass-lint:disable-next-line no -qualifying-elements
+  div[id^='google_ads_iframe_'] {
     margin: 0 auto;
   }
 

--- a/main.scss
+++ b/main.scss
@@ -66,7 +66,7 @@ $o-ads-is-silent: true !default;
 
   // HACK: This is necessary to overcome an issue introducedy by GPT that misplaces ads
   // See: https://ads.google.com/status#hl=en&v=issue&sid=24&iid=6790def915d959f61f56fb7005cba2cc
-  // sass-lint:disable-next-line no -qualifying-elements
+  // sass-lint:disable-next-line no-qualifying-elements
   div[id^='google_ads_iframe_'] {
     margin: 0 auto;
   }

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -38,8 +38,8 @@ module.exports = {
 			'ed72d2ac-cf4e-11e2-be7b-00144feab7de',
 			'cece477a-ceca-11e2-8e16-00144feab7de',
 			'af925250-c765-11e2-9c52-00144feab7de',
-			'bcbe1a6d-fa90-4db5-b4dc-424c69802310'
-
+			'bcbe1a6d-fa90-4db5-b4dc-424c69802310',
+			'6790def915d959f61f56fb7005cba2cc'
 		]
 	}
 };


### PR DESCRIPTION
This fixes the issue reported in our board (ADSDEV-131) in which GPT sets the width of an DOM element explicitly in an inline property causing the ads to align to the left rather than to the center.