### PR TITLE
expose a new util function for gpt to tell whether it has loaded

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -510,6 +510,10 @@ function updatePageTargeting(override) {
 		utils.log.warn('Attempting to set page targeting before the GPT library has initialized');
 	}
 }
+//https://developers.google.com/doubleclick-gpt/common_implementation_mistakes#scenario-2:-checking-the-googletag-object-to-know-whether-gpt-is-ready
+function hasGPTLoaded () {
+	return window.googletag && window.googletag.apiReady;
+}
 
 function debug() {
 	const log = utils.log;
@@ -527,6 +531,7 @@ export default {
 	updateCorrelator,
 	updatePageTargeting,
 	clearPageTargetingForKey,
-	debug,
-	loadGPT
+	hasGPTLoaded,
+	loadGPT,
+	debug
 };


### PR DESCRIPTION
Exposes a new function to tell whether gpt has properly loaded, picked from [here](https://developers.google.com/doubleclick-gpt/common_implementation_mistakes).

It's currently useful for tracking on top of the `serverScriptLoaded` and `adServerLoadError` events. 