### PR TITLE
Backwards compatibilty v1 ads api

### DIFF
--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -37,9 +37,9 @@ Api.prototype.handleResponse = function(response) {
 		const responseObj = response[i];
 		const keys = ['user', 'page'];
 		const behavioralMetaObj = {};
-		const behavioralResponseApi = responseObj.krux && responseObj.krux.attributes;
-		if(behavioralResponseApi ) {
-			behavioralMetaObj[keys[i]] = this.instance.utils.buildObjectFromArray(behavioralResponseApi);
+		const apiResponseBehavioral = responseObj.krux && responseObj.krux.attributes;
+		if(apiResponseBehavioral) {
+			behavioralMetaObj[keys[i]] = this.instance.utils.buildObjectFromArray(apiResponseBehavioral);
 			this.instance.config({'behavioralMeta' : behavioralMetaObj});
 		}
 

--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -36,10 +36,11 @@ Api.prototype.handleResponse = function(response) {
 	for(let i = 0; i < response.length; i++) {
 		const responseObj = response[i];
 		const keys = ['user', 'page'];
-		const kruxObj = {};
-		if(responseObj.krux && responseObj.krux.attributes) {
-			kruxObj[keys[i]] = this.instance.utils.buildObjectFromArray(responseObj.krux.attributes);
-			this.instance.config({'permutiveMeta' : kruxObj});
+		const behavioralMetaObj = {};
+		const behavioralResponseApi = responseObj.krux && responseObj.krux.attributes;
+		if(behavioralResponseApi ) {
+			behavioralMetaObj[keys[i]] = this.instance.utils.buildObjectFromArray(behavioralResponseApi);
+			this.instance.config({'behavioralMeta' : behavioralMetaObj});
 		}
 
 		if(responseObj.dfp && responseObj.dfp.targeting) {

--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -36,6 +36,13 @@ Api.prototype.handleResponse = function(response) {
 	for(let i = 0; i < response.length; i++) {
 		const responseObj = response[i];
 
+		const keys = ['user', 'page'];	
+		const kruxObj = {};	
+
+		if(responseObj.krux && responseObj.krux.attributes) {	
+			kruxObj[keys[i]] = this.instance.utils.buildObjectFromArray(responseObj.krux.attributes);		
+		}
+
 		if(responseObj.dfp && responseObj.dfp.targeting) {
 			this.instance.targeting.add(this.instance.utils.buildObjectFromArray(responseObj.dfp.targeting));
 		}

--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -39,6 +39,7 @@ Api.prototype.handleResponse = function(response) {
 		const kruxObj = {};
 		if(responseObj.krux && responseObj.krux.attributes) {
 			kruxObj[keys[i]] = this.instance.utils.buildObjectFromArray(responseObj.krux.attributes);
+			this.instance.config({'permutiveMeta' : kruxObj});
 		}
 
 		if(responseObj.dfp && responseObj.dfp.targeting) {

--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -35,10 +35,8 @@ Api.prototype.handleResponse = function(response) {
 
 	for(let i = 0; i < response.length; i++) {
 		const responseObj = response[i];
-
-		const keys = ['user', 'page'];	
-		const kruxObj = {};	
-
+		const keys = ['user', 'page'];
+		const kruxObj = {};
 		if(responseObj.krux && responseObj.krux.attributes) {	
 			kruxObj[keys[i]] = this.instance.utils.buildObjectFromArray(responseObj.krux.attributes);		
 		}

--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -37,8 +37,8 @@ Api.prototype.handleResponse = function(response) {
 		const responseObj = response[i];
 		const keys = ['user', 'page'];
 		const kruxObj = {};
-		if(responseObj.krux && responseObj.krux.attributes) {	
-			kruxObj[keys[i]] = this.instance.utils.buildObjectFromArray(responseObj.krux.attributes);		
+		if(responseObj.krux && responseObj.krux.attributes) {
+			kruxObj[keys[i]] = this.instance.utils.buildObjectFromArray(responseObj.krux.attributes);
 		}
 
 		if(responseObj.dfp && responseObj.dfp.targeting) {

--- a/test/cypress/integration/ad-requests.test.js
+++ b/test/cypress/integration/ad-requests.test.js
@@ -31,9 +31,9 @@ describe('Integration tests', () => {
 			const cust_params = getQueryParams(qsp.cust_params);
 
 			// Check sizes are converted and set
-			expect(qsp.prev_iu_szs).to.equal('300x250|180x50|160x600|728x90|970x90|970x66|300x600|970x250|300x1050|320x50|88x31|120x60|2x2');
+			expect(qsp.prev_iu_szs || qsp.sz).to.equal('300x250|180x50|160x600|728x90|970x90|970x66|300x600|970x250|300x1050|320x50|88x31|120x60|2x2');
 			// Check targeting is set
-			expect(qsp.prev_scp).to.equal('pos=top');
+			expect(qsp.prev_scp || qsp.scp).to.equal('pos=top');
 			// Check custom parameters are set
 			expect(cust_params).to.have.property('testparam', 'hello');
 			//

--- a/test/fixtures/content-api-response.json
+++ b/test/fixtures/content-api-response.json
@@ -15,5 +15,82 @@
             "value": "finance,company,business"
         }],
         "adUnit": ["companies", "technology"]
+    },
+    "krux": {
+        "attributes": [
+            {
+                "name": "topics",
+                "key": "topics",
+                "value": [
+                    "Brexit",
+                    "UK business & economy",
+                    "World",
+                    "Economy",
+                    "UK politics & policy",
+                    "Politics"
+                ]
+            },
+            {
+                "name": "people",
+                "key": "people",
+                "value": [
+                    "Boris Johnson",
+                    "Leo Varadkar",
+                    "Arthur Beesley",
+                    "George Parker"
+                ]
+            },
+            {
+                "name": "genre",
+                "key": "genre",
+                "value": [
+                    "News"
+                ]
+            },
+            {
+                "name": "authors",
+                "key": "authors",
+                "value": [
+                    "Arthur Beesley",
+                    "George Parker"
+                ]
+            },
+            {
+                "name": "admants",
+                "key": "ad",
+                "value": [
+                    "bs03",
+                    "bs06",
+                    "bs11",
+                    "bs14",
+                    "bs20",
+                    "bs24",
+                    "bs27",
+                    "bs28",
+                    "e2",
+                    "ft02",
+                    "ft16",
+                    "ft18",
+                    "ft27",
+                    "ft36",
+                    "ft63",
+                    "g1",
+                    "n1",
+                    "s01",
+                    "sm06",
+                    "sr05"
+                ]
+            },
+            {
+                "name": "categories",
+                "key": "ca",
+                "value": [
+                    "government",
+                    "politics",
+                    "referendums",
+                    "search"
+                ]
+            }
+        ]
     }
 }

--- a/test/fixtures/user-api-response.json
+++ b/test/fixtures/user-api-response.json
@@ -1,26 +1,79 @@
 {
     "uuid": "11111111-2222-3333-4444-555555555555",
     "dfp": {
-        "targeting": [{
-            "name": "subscription",
-            "key": "slv",
-            "value": "int"
-        }, {
-            "name": "loggedInStatus",
-            "key": "loggedIn",
-            "value": true
-        }, {
-            "name": "Spoor ID of Browser/Device",
-            "key": "device_spoor_id",
-            "value": "cis61kpxo00003k59j4xnd8kx"
-        }, {
-            "name": "User UUID",
-            "key": "guid",
-            "value": "11111111-2222-3333-4444-555555555555"
-        }, {
-            "name": "Derived gender from redshift",
-            "key": "gender",
-            "value": "F"
-        }]
+        "targeting": [
+            {
+                "name": "subscription",
+                "key": "slv",
+                "value": "int"
+            },
+            {
+                "name": "loggedInStatus",
+                "key": "loggedIn",
+                "value": true
+            },
+            {
+                "name": "Spoor ID of Browser/Device",
+                "key": "device_spoor_id",
+                "value": "cis61kpxo00003k59j4xnd8kx"
+            },
+            {
+                "name": "User UUID",
+                "key": "guid",
+                "value": "11111111-2222-3333-4444-555555555555"
+            },
+            {
+                "name": "Derived gender from redshift",
+                "key": "gender",
+                "value": "F"
+            }
+        ]
+    },
+    "krux": {
+        "attributes": [
+            {
+                "name": "Spoor ID of Browser/Device",
+                "key": "device_spoor_id",
+                "value": "abc"
+            },
+            {
+                "name": "User UUID",
+                "key": "guid",
+                "value": "abc"
+            },
+            {
+                "name": "subscription",
+                "key": "subscription_level",
+                "value": "int"
+            },
+            {
+                "name": "loggedInStatus",
+                "key": "loggedIn",
+                "value": true
+            },
+            {
+                "name": "industry",
+                "key": "industry",
+                "value": "map"
+            },
+            {
+                "name": "responsibility",
+                "key": "job_responsibility",
+                "value": "tec"
+            },
+            {
+                "name": "position",
+                "key": "job_position",
+                "value": "ts"
+            },
+            {
+                "name": "Derived gender from redshift",
+                "key": "gender"
+            },
+            {
+                "name": "Derived industry",
+                "key": "indb2b"
+            }
+        ]
     }
 }

--- a/test/qunit/api.test.js
+++ b/test/qunit/api.test.js
@@ -242,7 +242,7 @@ QUnit.test("makes api call to correct page/content url and adds correct data to 
 });
 
 
-QUnit.only("makes api call to correct page/content url and adds correct data to behavioral meta", function(assert) {
+QUnit.test("makes api call to correct page/content url and adds correct data to behavioral meta", function(assert) {
 	const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.content);
 	const userJSON = JSON.stringify(this.fixtures.user);
@@ -258,9 +258,8 @@ QUnit.only("makes api call to correct page/content url and adds correct data to 
 	});
 
 	ads.then((ads) => {
-		
 		const behavioralConf = ads.config('behavioralMeta');
-		console.log(behavioralConf);
+		//console.log(behavioralConf);
 		assert.ok(behavioralConf.page);
 		assert.ok(behavioralConf.user);
 

--- a/test/qunit/api.test.js
+++ b/test/qunit/api.test.js
@@ -241,6 +241,33 @@ QUnit.test("makes api call to correct page/content url and adds correct data to 
 	});
 });
 
+
+QUnit.only("makes api call to correct page/content url and adds correct data to behavioral meta", function(assert) {
+	const done = assert.async();
+	const pageJSON = JSON.stringify(this.fixtures.content);
+	const userJSON = JSON.stringify(this.fixtures.user);
+
+	fetchMock.get('https://ads-api.ft.com/v1/user', userJSON);
+	fetchMock.get('https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM=', pageJSON);
+
+	const ads = this.ads.init({
+		targetingApi: {
+			user: 'https://ads-api.ft.com/v1/user',
+			page: 'https://ads-api.ft.com/v1/concept/MTI1-U2VjdGlvbnM='
+		}
+	});
+
+	ads.then((ads) => {
+		
+		const behavioralConf = ads.config('behavioralMeta');
+		console.log(behavioralConf);
+		assert.ok(behavioralConf.page);
+		assert.ok(behavioralConf.user);
+
+		done();
+	});
+});
+
 QUnit.test("makes use of custom set timeout when calling getPageData directly", function(assert) {
 	const done = assert.async();
 	const pageJSON = JSON.stringify(this.fixtures.content);


### PR DESCRIPTION
o-ads currently contains a module for passing data from an api-end-point into `o-ads config`. 
In o-ads v13 some of this functionality was removed as it has been decided that the `data-providers/api` module will be deprecated in a future release.
In the short term however we've found that some of the previously removed functionality is still useful on FT.com.
This PR re-instates some functionality for marshalling the ads-api data and passing it on to consuming apps.