### PR TITLE
ADSDEV-350, stop search terms going into targeting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run: npm config set prefix "$HOME/.local"
       - run: npm i -g origami-build-tools@^8
       - run: $HOME/.local/bin/obt install
-      - run: $HOME/.local/bin/obt build
+      - run: $HOME/.local/bin/obt build --production
       - run: $HOME/.local/bin/obt verify
       - run: npm run checksizes
       # `obt test` doesn't work because of custom karma config, so we run:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "demo-server": "obt demo --runServer --port=3002",
     "nightwatch-bs": "node ./test/nightwatch/config/nightwatch-local.js -c ./test/nightwatch/config/nightwatch.conf.bs.js",
     "test": "npm run test-unit",
-    "test-unit": "karma start karma.conf.js --single-run && jest",
+    "test-coverage": "karma start karma.conf.js --single-run",
+    "test-unit": "jest",
     "test-cy:run": "cypress run -r spec --record false",
     "test-cy:open": "cypress open",
     "test-nw": "npm run test-nw:basic && npm run test-nw:extended",
@@ -88,6 +89,7 @@
   "config": {
     "pre-git": {
       "pre-commit": [
+        "npx obt verify",
         "node_modules/.bin/secret-squirrel"
       ],
       "pre-push": [

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	useTabs: true,
+	singleQuote: true,
+	printWidth: 120
+};

--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -2,14 +2,16 @@
 /* eslint no-inner-declarations: 1 */
 
 /**
-* @fileOverview
-* ad server modules for o-ads implementing Google publisher tags ad requests.
-*
-* @author Robin Marr, robin.marr@ft.com
-*/
+ * @fileOverview
+ * ad server modules for o-ads implementing Google publisher tags ad requests.
+ *
+ * @author Robin Marr, robin.marr@ft.com
+ */
 import config from '../config';
 import utils from '../utils';
 import targeting from '../targeting';
+import { stripUrlParams, SEARCH_PARAMS } from '../utils/url';
+
 const DEFAULT_COLLAPSE_MODE = 'never';
 let breakpoints = false;
 /*
@@ -19,8 +21,8 @@ let breakpoints = false;
 */
 
 /*
-* Initialise Google publisher tags functionality
-*/
+ * Initialise Google publisher tags functionality
+ */
 function init() {
 	const gptConfig = config('gpt') || {};
 	breakpoints = config('responsive');
@@ -33,8 +35,8 @@ function init() {
 }
 
 /*
-* initalise the googletag global namespace and add the google publish tags library to the page
-*/
+ * initalise the googletag global namespace and add the google publish tags library to the page
+ */
 function loadGPT() {
 	if (!window.googletag) {
 		// set up a place holder for the gpt code downloaded from google
@@ -46,9 +48,15 @@ function loadGPT() {
 		window.googletag.cmd = [];
 	}
 
-	utils.attach('//securepubads.g.doubleclick.net/tag/js/gpt.js', true,
-		() => { utils.broadcast('serverScriptLoaded'); },
-		(err) => { utils.broadcast('adServerLoadError', err); }
+	utils.attach(
+		'//securepubads.g.doubleclick.net/tag/js/gpt.js',
+		true,
+		() => {
+			utils.broadcast('serverScriptLoaded');
+		},
+		err => {
+			utils.broadcast('adServerLoadError', err);
+		}
 	);
 }
 
@@ -59,10 +67,10 @@ function loadGPT() {
 */
 
 /*
-* Configure the GPT library for the current page
-* this method is pushed onto the googletag command queue and run
-* when the library is available
-*/
+ * Configure the GPT library for the current page
+ * this method is pushed onto the googletag command queue and run
+ * when the library is available
+ */
 function setup(gptConfig) {
 	const nonPersonalized = config('nonPersonalized') ? 1 : 0;
 	googletag.pubads().addEventListener('slotRenderEnded', onRenderEnded);
@@ -70,16 +78,23 @@ function setup(gptConfig) {
 	setRenderingMode(gptConfig);
 	setPageTargeting(targeting.get());
 	setPageCollapseEmpty();
+
+	const url = stripUrlParams({
+		href: window.location.href,
+		filters: { root: SEARCH_PARAMS }
+	});
+
 	googletag.enableServices();
-	googletag.pubads().setTargeting('url', window.location.href);
+	googletag.pubads().setTargeting('url', url);
 	googletag.pubads().setRequestNonPersonalizedAds(nonPersonalized);
+
 	return true;
 }
 
 /*
-* set the gpt rendering mode to either sync or async
-* default is async
-*/
+ * set the gpt rendering mode to either sync or async
+ * default is async
+ */
 
 function setRenderingMode(gptConfig) {
 	const rendering = gptConfig.rendering;
@@ -93,11 +108,11 @@ function setRenderingMode(gptConfig) {
 }
 
 /**
-* Adds page targeting to GPT ad calls
-* @name setPageTargeting
-* @memberof GPT
-* @lends GPT
-*/
+ * Adds page targeting to GPT ad calls
+ * @name setPageTargeting
+ * @memberof GPT
+ * @lends GPT
+ */
 function setPageTargeting(targetingData) {
 	if (utils.isPlainObject(targetingData)) {
 		googletag.cmd.push(() => {
@@ -116,8 +131,8 @@ function setPageTargeting(targetingData) {
 }
 
 /**
-* Removes page targeting for a specified key from GPT ad calls
-*/
+ * Removes page targeting for a specified key from GPT ad calls
+ */
 function clearPageTargetingForKey(key) {
 	if (!window.googletag) {
 		utils.log.warn('Attempting to clear page targeting before the GPT library has initialized');
@@ -133,11 +148,11 @@ function clearPageTargetingForKey(key) {
 }
 
 /**
-* Sets behaviour of empty slots can be 'after', 'before' or 'never'
-* * 'after' collapse slots that return an empty ad
-* * 'before' collapses all slots and only displays them when an ad is found
-* * 'never' does not collapse any empty slot, the collapseEmptyDivs method is not called in that case
-*/
+ * Sets behaviour of empty slots can be 'after', 'before' or 'never'
+ * * 'after' collapse slots that return an empty ad
+ * * 'before' collapses all slots and only displays them when an ad is found
+ * * 'never' does not collapse any empty slot, the collapseEmptyDivs method is not called in that case
+ */
 function setPageCollapseEmpty() {
 	const mode = config('collapseEmpty');
 
@@ -151,9 +166,9 @@ function setPageCollapseEmpty() {
 }
 
 /**
-* When companions are enabled we delay the rendering of ad slots until
-* either a master is returned or all slots are returned without a master
-*/
+ * When companions are enabled we delay the rendering of ad slots until
+ * either a master is returned or all slots are returned without a master
+ */
 function enableCompanions(gptConfig) {
 	if (gptConfig.companions) {
 		googletag.pubads().disableInitialLoad();
@@ -168,8 +183,8 @@ function enableCompanions(gptConfig) {
 */
 
 /*
-* Event handler for when a slot is ready for an ad to rendered
-*/
+ * Event handler for when a slot is ready for an ad to rendered
+ */
 function onReady(slotMethods, event) {
 	const slot = event.detail.slot;
 	/* istanbul ignore else  */
@@ -181,7 +196,8 @@ function onReady(slotMethods, event) {
 
 		// setup the gpt configuration the ad
 		googletag.cmd.push(() => {
-			slot.defineSlot()
+			slot
+				.defineSlot()
 				.addServices()
 				.setCollapseEmpty()
 				.setTargeting()
@@ -194,8 +210,8 @@ function onReady(slotMethods, event) {
 	}
 }
 /*
-* Render is called when a slot is not rendered when the ready event fires
-*/
+ * Render is called when a slot is not rendered when the ready event fires
+ */
 function onRender(event) {
 	const slot = event.detail.slot;
 	/* istanbul ignore else  */
@@ -205,8 +221,8 @@ function onRender(event) {
 }
 
 /*
-* refresh is called when a slot requests the ad be flipped
-*/
+ * refresh is called when a slot requests the ad be flipped
+ */
 function onRefresh(event) {
 	window.googletag.cmd.push(() => {
 		const targeting = event.detail.targeting;
@@ -228,8 +244,8 @@ function onResize(event) {
 }
 
 /*
-* function passed to the gpt library that is run when an ad completes rendering
-*/
+ * function passed to the gpt library that is run when an ad completes rendering
+ */
 function onRenderEnded(event) {
 	const data = {
 		gpt: {}
@@ -277,8 +293,8 @@ function onRenderEnded(event) {
 */
 const slotMethods = {
 	/**
-	* define a GPT slot
-	*/
+	 * define a GPT slot
+	 */
 	defineSlot: function() {
 		window.googletag.cmd.push(() => {
 			this.gpt.id = `${this.name}-gpt`;
@@ -291,8 +307,7 @@ const slotMethods = {
 				} else {
 					this.gpt.slot = googletag.defineSlot(this.gpt.unitName, this.sizes, this.gpt.id);
 				}
-			}
-			else {
+			} else {
 				this.gpt.slot = googletag.defineOutOfPageSlot(this.gpt.unitName, this.gpt.id);
 			}
 		});
@@ -308,21 +323,25 @@ const slotMethods = {
 	},
 	initResponsive: function() {
 		window.googletag.cmd.push(() => {
-			utils.on('breakpoint', (event) => {
-				const slot = event.detail.slot;
-				const screensize = event.detail.screensize;
+			utils.on(
+				'breakpoint',
+				event => {
+					const slot = event.detail.slot;
+					const screensize = event.detail.screensize;
 
-				updatePageTargeting({ res: screensize });
+					updatePageTargeting({ res: screensize });
 
-				if (slot.hasValidSize(screensize)) {
-					/* istanbul ignore else  */
-					if (slot.gpt.iframe) {
-						slot.fire('refresh');
-					} else if (!this.defer) {
-						slot.display();
+					if (slot.hasValidSize(screensize)) {
+						/* istanbul ignore else  */
+						if (slot.gpt.iframe) {
+							slot.fire('refresh');
+						} else if (!this.defer) {
+							slot.display();
+						}
 					}
-				}
-			}, this.container);
+				},
+				this.container
+			);
 
 			const mapping = googletag.sizeMapping();
 			Object.keys(breakpoints).forEach(breakpoint => {
@@ -337,8 +356,8 @@ const slotMethods = {
 	},
 
 	/**
-	* Tell gpt to destroy the slot and its metadata
-	*/
+	 * Tell gpt to destroy the slot and its metadata
+	 */
 	destroySlot: function(gptSlot) {
 		if (window.googletag.pubadsReady && window.googletag.pubads) {
 			gptSlot = gptSlot || this.gpt.slot;
@@ -348,8 +367,8 @@ const slotMethods = {
 		}
 	},
 	/*
-	*	Tell gpt to request an ad
-	*/
+	 *	Tell gpt to request an ad
+	 */
 	display: function() {
 		window.googletag.cmd.push(() => {
 			this.fire('slotGoRender');
@@ -358,8 +377,8 @@ const slotMethods = {
 		return this;
 	},
 	/**
-	* Set the DFP unit name for the slot.
-	*/
+	 * Set the DFP unit name for the slot.
+	 */
 	setUnitName: function() {
 		window.googletag.cmd.push(() => {
 			let unitName;
@@ -383,8 +402,8 @@ const slotMethods = {
 		return this;
 	},
 	/**
-	* Add the slot to the pub ads service and add a companion service if configured
-	*/
+	 * Add the slot to the pub ads service and add a companion service if configured
+	 */
 	addServices: function(gptSlot) {
 		window.googletag.cmd.push(() => {
 			const gpt = config('gpt') || {};
@@ -398,9 +417,9 @@ const slotMethods = {
 	},
 
 	/**
-	* Sets the GPT collapse empty mode for a given slot
-	* values can be 'after', 'before', 'never'
-	*/
+	 * Sets the GPT collapse empty mode for a given slot
+	 * values can be 'after', 'before', 'never'
+	 */
 	setCollapseEmpty: function() {
 		window.googletag.cmd.push(() => {
 			const mode = this.collapseEmpty || config('collapseEmpty') || DEFAULT_COLLAPSE_MODE;
@@ -416,7 +435,7 @@ const slotMethods = {
 
 		return this;
 	},
-	submitGptImpression : function() {
+	submitGptImpression: function() {
 		/* istanbul ignore next  */
 		function getImpressionURL(iframe) {
 			const trackingUrlElement = iframe.contentWindow.document.querySelector('[data-o-ads-impression-url]');
@@ -428,11 +447,12 @@ const slotMethods = {
 			}
 		}
 		if (this.outOfPage && this.gpt.iframe) {
-
 			const impressionURL = getImpressionURL(this.gpt.iframe);
 			/* istanbul ignore next  */
-			if(impressionURL){
-				utils.attach(impressionURL, true,
+			if (impressionURL) {
+				utils.attach(
+					impressionURL,
+					true,
 					() => {
 						utils.log.info('Impression Url requested');
 					},
@@ -442,15 +462,14 @@ const slotMethods = {
 					true
 				);
 			}
-		}
-		else {
+		} else {
 			utils.log.warn('Attempting to call submitImpression on a non-oop slot');
 		}
 	},
 	/**
-	* Sets page url to be sent to google
-	* prevents later url changes via javascript from breaking the ads
-	*/
+	 * Sets page url to be sent to google
+	 * prevents later url changes via javascript from breaking the ads
+	 */
 	setURL: function(gptSlot) {
 		window.googletag.cmd.push(() => {
 			gptSlot = gptSlot || this.gpt.slot;
@@ -461,8 +480,8 @@ const slotMethods = {
 	},
 
 	/**
-	* Adds key values from a given object to the slot targeting
-	*/
+	 * Adds key values from a given object to the slot targeting
+	 */
 	setTargeting: function(gptSlot) {
 		window.googletag.cmd.push(() => {
 			gptSlot = gptSlot || this.gpt.slot;
@@ -474,7 +493,7 @@ const slotMethods = {
 			}
 		});
 		return this;
-	},
+	}
 };
 
 /*
@@ -484,12 +503,14 @@ const slotMethods = {
 */
 
 /**
-* The correlator is a random number added to ad calls.
-* It is used by the ad server to determine which impressions where served to the same page
-* Updating is used to tell the ad server to treat subsequent ad calls as being on a new page
-*/
+ * The correlator is a random number added to ad calls.
+ * It is used by the ad server to determine which impressions where served to the same page
+ * Updating is used to tell the ad server to treat subsequent ad calls as being on a new page
+ */
 function updateCorrelator() {
-	utils.log.warn('[DEPRECATED]: Updatecorrelator is being phased out by google and removed from o-ads in future releases.');
+	utils.log.warn(
+		'[DEPRECATED]: Updatecorrelator is being phased out by google and removed from o-ads in future releases.'
+	);
 
 	googletag.cmd.push(() => {
 		googletag.pubads().updateCorrelator();
@@ -505,13 +526,12 @@ function updatePageTargeting(override) {
 			});
 		}
 		setPageTargeting(params);
-	}
-	else {
+	} else {
 		utils.log.warn('Attempting to set page targeting before the GPT library has initialized');
 	}
 }
 //https://developers.google.com/doubleclick-gpt/common_implementation_mistakes#scenario-2:-checking-the-googletag-object-to-know-whether-gpt-is-ready
-function hasGPTLoaded () {
+function hasGPTLoaded() {
 	if (window.googletag && window.googletag.apiReady) {
 		return true;
 	} else {
@@ -522,7 +542,7 @@ function hasGPTLoaded () {
 function debug() {
 	const log = utils.log;
 	const conf = config('gpt');
-	if(!conf){
+	if (!conf) {
 		return;
 	}
 
@@ -530,6 +550,7 @@ function debug() {
 	log.attributeTable(conf);
 	log.end();
 }
+
 export default {
 	init,
 	updateCorrelator,

--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -1,0 +1,75 @@
+export const SEARCH_PARAMS = ['q', 'kw'];
+
+/**
+ * @typedef {{ [key: string]: string[] }} FilterDict
+ */
+
+/**
+ * Remove unwanted params from nested query strings
+ *
+ * @param   {string}   nestedParams the URIencoded nested params
+ * @param   {string[]} keysToStrip  the parameters to remove
+ *
+ * @return  {string}               [return description]
+ */
+export function filterNestedParams(nestedParams, keysToStrip) {
+	if (!keysToStrip || keysToStrip.length < 1) {
+		return nestedParams;
+	}
+
+	const childParams = new URLSearchParams(nestedParams);
+
+	for (const key of keysToStrip) {
+		childParams.delete(key);
+	}
+
+	return childParams.toString();
+}
+
+/**
+ * Purge a URL of sensitive data in query strings
+ *
+ * Given the URL
+ * ```url
+ * https://www.ft.com/search?q=goog&cust_params=a%3D1%26b%3D2%26c%3D3%26d%3D4
+ * ```
+ * Supplying an object in the form
+ * ```
+ * {
+ *   root: ['q', 'kw'],
+ *   cust_params: ['a', 'c']
+ * }
+ * ```
+ * will remove `q` from the main query string and `a`, `c` from the nested params
+ * under `cust_params`:
+ * ```url
+ * https://www.ft.com/search?cust_params=b=2%26d%3D4
+ * ```
+ *
+ * @param   {Object}  params
+ * @param   {string | Location}  params.href     The base URL or `window.location`
+ * @param   {FilterDict}         params.filters  The dictionary of params to be removed
+ *
+ * @return  {string}              A URL that has been stripped of the supplied params
+ */
+export function stripUrlParams({ href, filters }) {
+	// @ts-ignore: URL absolutely accepts Location!
+	const url = new URL(href);
+
+	for (const [param, filter] of Object.entries(filters)) {
+		if (param === 'root') {
+			// Strip parameters from the main query string
+			for (const key of filter) {
+				url.searchParams.delete(key);
+			}
+		} else {
+			// Handle nested parameters
+			const nestedParams = url.searchParams.get(param);
+			if (nestedParams) {
+				url.searchParams.set(param, filterNestedParams(nestedParams, filter));
+			}
+		}
+	}
+
+	return url.href;
+}

--- a/test/jest/utils/url.js
+++ b/test/jest/utils/url.js
@@ -1,0 +1,96 @@
+/* eslint-env jest */
+
+import {
+	stripUrlParams,
+	filterNestedParams,
+	SEARCH_PARAMS
+} from '../../../src/js/utils/url';
+
+describe('filterNestedParams', () => {
+	describe.each([
+		[['', SEARCH_PARAMS], ''],
+		[['q=goog', SEARCH_PARAMS], ''],
+		[['q=goog&a=1&b=2&c=3', SEARCH_PARAMS], 'a=1&b=2&c=3'],
+		[['q=goog&a=1&b=2&c=3', ["a", "b", "x"]], 'q=goog&c=3'],
+		[['q=goog&a=1&b=2&c=3', null], 'q=goog&a=1&b=2&c=3'],
+		[['q=goog&a=1&b=2&c=3', undefined], 'q=goog&a=1&b=2&c=3'],
+		[['q=goog&a=1&b=2&c=3', []], 'q=goog&a=1&b=2&c=3'],
+	])('filterNestedParams(%s)', (input, expected) => {
+		test(`returns ${expected}`, () => {
+			// @ts-ignore: destructuring is correct
+			expect(filterNestedParams(...input)).toBe(expected);
+		});
+	});
+});
+
+describe('it can consume an instance of window.location', () => {
+	const location = {
+		href: 'https://www.ft.com/search?q=goog',
+		origin: 'https://www.ft.com',
+		protocol: 'https:',
+		host: 'www.ft.com',
+		hostname: 'www.ft.com',
+		port: '',
+		pathname: '/search',
+		search: '?q=goog',
+		hash: '',
+		toString: function() {
+			return this.href;
+		}
+	};
+	const filters = { root: SEARCH_PARAMS };
+
+	describe.each([[{ href: location, filters }, 'https://www.ft.com/search']])(
+		'stripUrlParams(%o)',
+		({ href, filters }, expected) => {
+			test(`returns ${expected}`, () => {
+				expect(stripUrlParams({ href, filters })).toBe(expected);
+			});
+		}
+	);
+});
+
+describe('it can consume strings', () => {
+	const filters = { root: SEARCH_PARAMS };
+
+	describe.each([
+		[
+			{ href: 'https://www.ft.com/search?q=goog', filters },
+			'https://www.ft.com/search'
+		],
+		[
+			{ href: 'https://www.ft.com/search?kw=goog', filters },
+			'https://www.ft.com/search'
+		],
+		[
+			{
+				href:
+					'https://www.ft.com/search?q=goog&dateRange=now-30d&sort=relevance&expandRefinements=true&contentType=video',
+				filters: { root: [...SEARCH_PARAMS, 'contentType'] }
+			},
+			'https://www.ft.com/search?dateRange=now-30d&sort=relevance&expandRefinements=true'
+		]
+	])('stripUrlParams(%o)', (input, expected) => {
+		test(`returns ${expected}`, () => {
+			expect(stripUrlParams(input)).toBe(expected);
+		});
+	});
+});
+
+describe('It can consume complex nested URLs', () => {
+	const filters = {
+		root: ['gdfp_req', 'correlator', 'missing'],
+		cust_params: [...SEARCH_PARAMS, 'url', 'missing']
+	};
+
+	describe.each([
+		[
+			'https://securepubads.g.doubleclick.net/gampad/ads?gdfp_req=1&correlator=1582019632810904&output=json_html&impl=fif&sc=1&sfv=1-0-4&iu=%2F5887%2Fft.com/world&sz=320x50&fluid=height&scp=pos%3Dnative&d_imp=1&ga_sid=1582019632810&cust_params=device_spoor_id%3Dck6rpj5hv00012z5t4piclqpi%26guid%3D01168978-c5e1-4701-a2bb-6d0771485525%26slv%3Dreg%26loggedIn%3Dtrue%2605%3Dacc%2606%3Dfin%2607%3Dan%26cc%3Dy%26pt%3Dstr%26nlayout%3Ddefault%26mvt%3DsubscriberCohort%25253Aon%25252Cxteaserpagesv2%25253Avariant%25252CadsAppLazyloadingThresholdsMVT%25253Acontrol%25252CmanageCancellationJourney%25253Acontrol%25252Candroidactionbar%25253Avariant%25252CmyFTTopicCarousel%25253Acontrol%25252CmyFTDedupingStrategy%25253Acontrol%26rootid%3Dck6rpn4z500012z5tpu7jw1fk%26ts%3D20200218095352%26res%3Dextra%26ftpb%3D1%26url%3Dhttps%253A%252F%252Fwww.ft.com%252Fworld%26q%3Dgoog',
+			'https://securepubads.g.doubleclick.net/gampad/ads?output=json_html&impl=fif&sc=1&sfv=1-0-4&iu=%2F5887%2Fft.com%2Fworld&sz=320x50&fluid=height&scp=pos%3Dnative&d_imp=1&ga_sid=1582019632810&cust_params=device_spoor_id%3Dck6rpj5hv00012z5t4piclqpi%26guid%3D01168978-c5e1-4701-a2bb-6d0771485525%26slv%3Dreg%26loggedIn%3Dtrue%2605%3Dacc%2606%3Dfin%2607%3Dan%26cc%3Dy%26pt%3Dstr%26nlayout%3Ddefault%26mvt%3DsubscriberCohort%25253Aon%25252Cxteaserpagesv2%25253Avariant%25252CadsAppLazyloadingThresholdsMVT%25253Acontrol%25252CmanageCancellationJourney%25253Acontrol%25252Candroidactionbar%25253Avariant%25252CmyFTTopicCarousel%25253Acontrol%25252CmyFTDedupingStrategy%25253Acontrol%26rootid%3Dck6rpn4z500012z5tpu7jw1fk%26ts%3D20200218095352%26res%3Dextra%26ftpb%3D1'
+		]
+	])('stripUrlParams(doubleclickUrl)', (input, expected) => {
+		test(`returns ${expected}`, () => {
+			expect(stripUrlParams({ href: input, filters })).toBe(expected);
+		});
+	});
+});

--- a/test/qunit/gpt.test.js
+++ b/test/qunit/gpt.test.js
@@ -5,15 +5,22 @@
 const htmlstart = '<div data-o-ads-name="';
 const htmlend = '" data-o-ads-formats="MediumRectangle"></div>';
 
-QUnit.module('gpt', {
-});
+QUnit.module('gpt', {});
 
 QUnit.test('init', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
 	this.ads.init();
-	assert.ok(this.ads.utils.attach.calledWith('//securepubads.g.doubleclick.net/tag/js/gpt.js', true, sinon.match.typeOf('function'), sinon.match.typeOf('function')), 'google publisher tag library is attached to the page');
+	assert.ok(
+		this.ads.utils.attach.calledWith(
+			'//securepubads.g.doubleclick.net/tag/js/gpt.js',
+			true,
+			sinon.match.typeOf('function'),
+			sinon.match.typeOf('function')
+		),
+		'google publisher tag library is attached to the page'
+	);
 	assert.ok(window.googletag, 'placeholder googletag object is created');
 	assert.ok(window.googletag.cmd.length, 'library setup is added to the command queue');
 
@@ -43,30 +50,34 @@ QUnit.test('broadcast an event when GPT fails to load', function(assert) {
 	this.ads.init();
 
 	assert.ok(this.ads.utils.broadcast.calledWith('adServerLoadError', 'some error'));
-
 });
 
 QUnit.test('set page targeting', function(assert) {
-	this.ads.init({ dfp_targeting: ';some=test;targeting=params'});
+	this.ads.init({ dfp_targeting: ';some=test;targeting=params' });
 	assert.ok(googletag.pubads().setTargeting.calledWith('some', 'test'), 'the params are queued with GPT');
 	assert.ok(googletag.pubads().setTargeting.calledWith('targeting', 'params'), 'the params are queued with GPT');
 });
 
 QUnit.test('override page targeting', function(assert) {
-	this.ads.init({ dfp_targeting: ';some=test;targeting=params'});
+	this.ads.init({ dfp_targeting: ';some=test;targeting=params' });
 	assert.ok(googletag.pubads().setTargeting.calledWith('some', 'test'), 'the params are queued with GPT');
 	assert.ok(googletag.pubads().setTargeting.calledWith('targeting', 'params'), 'the params are queued with GPT');
 
-	this.ads.gpt.updatePageTargeting({overrideKey: 'overrideValue'});
-	assert.ok(googletag.pubads().setTargeting.calledWith('overrideKey', 'overrideValue'), 'the params are queued with GPT');
+	this.ads.gpt.updatePageTargeting({ overrideKey: 'overrideValue' });
+	assert.ok(
+		googletag.pubads().setTargeting.calledWith('overrideKey', 'overrideValue'),
+		'the params are queued with GPT'
+	);
 
 	this.ads.gpt.updatePageTargeting('anotherOverrideKey=anotherOverrideValue');
-	assert.ok(googletag.pubads().setTargeting.neverCalledWith('anotherOverrideKey', 'anotherOverrideValue'), 'overreide paramerters passed as a string are not queued with GPT');
-
+	assert.ok(
+		googletag.pubads().setTargeting.neverCalledWith('anotherOverrideKey', 'anotherOverrideValue'),
+		'overreide paramerters passed as a string are not queued with GPT'
+	);
 });
 
 QUnit.test('empty override page targeting clears targeting', function(assert) {
-	this.ads.init({ dfp_targeting: ';some=test;targeting=params'});
+	this.ads.init({ dfp_targeting: ';some=test;targeting=params' });
 	this.ads.gpt.updatePageTargeting();
 	assert.ok(googletag.pubads().clearTargeting.called);
 });
@@ -76,8 +87,11 @@ QUnit.test('override page targetting catches and warns when googletag is not ava
 	this.ads.init();
 	// delete mock
 	delete window.googletag;
-	this.ads.gpt.updatePageTargeting({overrideKey: 'overrideValue'});
-	assert.ok(errorSpy.calledWith('Attempting to set page targeting before the GPT library has initialized'), 'warns that googletag is not available');
+	this.ads.gpt.updatePageTargeting({ overrideKey: 'overrideValue' });
+	assert.ok(
+		errorSpy.calledWith('Attempting to set page targeting before the GPT library has initialized'),
+		'warns that googletag is not available'
+	);
 
 	// reinstate mock
 	window.googletag = this.gpt;
@@ -90,67 +104,88 @@ QUnit.test('unset page targeting', function(assert) {
 	assert.ok(googletag.pubads().clearTargeting.calledWith('test'), 'removals of custom params are queued with GPT');
 });
 
-QUnit.test('unsetting page targeting catches and warns when about to unset all or if googletag is not available', function(assert) {
-	const errorSpy = this.spy(this.utils.log, 'warn');
-	this.ads.init();
+QUnit.test(
+	'unsetting page targeting catches and warns when about to unset all or if googletag is not available',
+	function(assert) {
+		const errorSpy = this.spy(this.utils.log, 'warn');
+		this.ads.init();
 
-	this.ads.gpt.clearPageTargetingForKey();
-	assert.ok(errorSpy.calledWith('Refusing to unset all keys - a key must be specified'), 'all params are not accidentally cleared');
+		this.ads.gpt.clearPageTargetingForKey();
+		assert.ok(
+			errorSpy.calledWith('Refusing to unset all keys - a key must be specified'),
+			'all params are not accidentally cleared'
+		);
 
-	// delete mock
-	delete window.googletag;
-	this.ads.gpt.clearPageTargetingForKey('test');
-	assert.ok(errorSpy.calledWith('Attempting to clear page targeting before the GPT library has initialized'), 'warns that googletag is not available');
+		// delete mock
+		delete window.googletag;
+		this.ads.gpt.clearPageTargetingForKey('test');
+		assert.ok(
+			errorSpy.calledWith('Attempting to clear page targeting before the GPT library has initialized'),
+			'warns that googletag is not available'
+		);
 
-	// reinstate mock
-	window.googletag = this.gpt;
-});
+		// reinstate mock
+		window.googletag = this.gpt;
+	}
+);
 
 QUnit.test('set sync rendering', function(assert) {
-	this.ads.init({ gpt: {rendering: 'sync'}});
+	this.ads.init({ gpt: { rendering: 'sync' } });
 	assert.ok(googletag.pubads().enableSyncRendering.calledOnce, 'sync rendering has been enabled');
 });
 
 QUnit.test('enabled single request', function(assert) {
-	this.ads.init({ gpt: {rendering: 'sra'}});
+	this.ads.init({ gpt: { rendering: 'sra' } });
 	assert.ok(googletag.pubads().enableSingleRequest.calledOnce, 'single request has been enabled');
 });
 
 QUnit.test('default to async rendering', function(assert) {
-	this.ads.init({ gpt: {rendering: 'random'}});
+	this.ads.init({ gpt: { rendering: 'random' } });
 	assert.ok(googletag.pubads().enableAsyncRendering.calledOnce, 'async rendering has been enabled by default');
 });
 
 QUnit.test('enables companion ads', function(assert) {
-	this.ads.init({ gpt: {companions: true}});
+	this.ads.init({ gpt: { companions: true } });
 	assert.ok(googletag.pubads().disableInitialLoad.calledOnce, 'disabled the initial load');
 	assert.ok(googletag.companionAds.calledOnce, 'companion ads called');
 	assert.ok(googletag.companionAds().setRefreshUnfilledSlots.calledOnce, 'companion ads api called');
-	assert.ok(googletag.companionAds().setRefreshUnfilledSlots.calledWith(true), 'companion ads api called with correct param');
+	assert.ok(
+		googletag.companionAds().setRefreshUnfilledSlots.calledWith(true),
+		'companion ads api called with correct param'
+	);
 });
 
 QUnit.test('set correct collapse mode when config collapseEmpty is after', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({collapseEmpty: 'after'});
+	this.ads.init({ collapseEmpty: 'after' });
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(
+		slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true),
+		'call collapse empty slot gpt api with correct parameters'
+	);
 });
 
 QUnit.test('set correct collapse mode when config collapseEmpty is before', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({collapseEmpty: 'before'});
+	this.ads.init({ collapseEmpty: 'before' });
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(
+		slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true),
+		'call collapse empty slot gpt api with correct parameters'
+	);
 });
 
 QUnit.test('set correct collapse mode when config collapseEmpty is never', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({collapseEmpty: 'never'});
+	this.ads.init({ collapseEmpty: 'never' });
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(false), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(
+		slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(false),
+		'call collapse empty slot gpt api with correct parameters'
+	);
 });
 
 QUnit.test('set collapse mode as "never" if no mode is specified', function(assert) {
@@ -158,48 +193,78 @@ QUnit.test('set collapse mode as "never" if no mode is specified', function(asse
 	this.ads.init({});
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(false), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(
+		slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(false),
+		'call collapse empty slot gpt api with correct parameters'
+	);
 });
 
 QUnit.test('component specific mode overrides config set parameter', function(assert) {
-	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle" data-o-ads-collapse-empty="before"></div>');
-	this.ads.init({collapseEmpty: 'after'});
+	this.fixturesContainer.add(
+		'<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle" data-o-ads-collapse-empty="before"></div>'
+	);
+	this.ads.init({ collapseEmpty: 'after' });
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(
+		slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true),
+		'call collapse empty slot gpt api with correct parameters'
+	);
 });
 
 QUnit.test('component specific mode overrides default', function(assert) {
-	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle" data-o-ads-collapse-empty="before"></div>');
+	this.fixturesContainer.add(
+		'<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle" data-o-ads-collapse-empty="before"></div>'
+	);
 	this.ads.init({});
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(
+		slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true),
+		'call collapse empty slot gpt api with correct parameters'
+	);
 });
 
-QUnit.test('component specific mode is not set if attribute value is wrong, and the config set mode is set instead', function(assert) {
-	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle" data-o-ads-collapse-empty="INVALID_PARAMETER"></div>');
-	this.ads.init({collapseEmpty: 'after'});
-	const slot = this.ads.slots.initSlot('mpu');
-	assert.ok(slot.collapseEmpty === undefined, 'collapse empty is not set when attribute value is wrong');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true), 'call collapse empty slot gpt api with correct parameters');
-});
+QUnit.test(
+	'component specific mode is not set if attribute value is wrong, and the config set mode is set instead',
+	function(assert) {
+		this.fixturesContainer.add(
+			'<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle" data-o-ads-collapse-empty="INVALID_PARAMETER"></div>'
+		);
+		this.ads.init({ collapseEmpty: 'after' });
+		const slot = this.ads.slots.initSlot('mpu');
+		assert.ok(slot.collapseEmpty === undefined, 'collapse empty is not set when attribute value is wrong');
+		assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
+		assert.ok(
+			slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true),
+			'call collapse empty slot gpt api with correct parameters'
+		);
+	}
+);
 
 QUnit.test('named component config overrides global config', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({ collapseEmpty: 'after', slots: { mpu: { collapseEmpty: 'before'}}});
+	this.ads.init({
+		collapseEmpty: 'after',
+		slots: { mpu: { collapseEmpty: 'before' } }
+	});
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(
+		slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true),
+		'call collapse empty slot gpt api with correct parameters'
+	);
 });
 
 QUnit.test('named component config overrides default', function(assert) {
 	this.fixturesContainer.add('<div data-o-ads-name="mpu" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({slots: { mpu: { collapseEmpty: 'before'}}});
+	this.ads.init({ slots: { mpu: { collapseEmpty: 'before' } } });
 	const slot = this.ads.slots.initSlot('mpu');
 	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledOnce, 'call collapse empty slot gpt api');
-	assert.ok(slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true), 'call collapse empty slot gpt api with correct parameters');
+	assert.ok(
+		slot.gpt.slot.setCollapseEmptyDiv.calledWithExactly(true, true),
+		'call collapse empty slot gpt api with correct parameters'
+	);
 });
 
 QUnit.test('catches slot in view render event and display it if method is ready', function(assert) {
@@ -217,7 +282,7 @@ QUnit.test('on slot refresh event updates targeting', function(assert) {
 	const node = this.fixturesContainer.add(slotHTML);
 	this.ads.init();
 	const slot = this.ads.slots.initSlot(node);
-	slot.fire('refresh', {targeting: {test: true}});
+	slot.fire('refresh', { targeting: { test: true } });
 	assert.ok(googletag.pubads().refresh.calledOnce, 'googletag refresh method has been called');
 	assert.ok(slot.gpt.slot.setTargeting.calledTwice, 'setTargeting has been called on the slot');
 	assert.ok(slot.gpt.slot.setTargeting.calledWith('random', '1'), 'setTargeting has been passed correct argument');
@@ -254,11 +319,15 @@ QUnit.test('provides api to clear the slot', function(assert) {
 	const slot = this.ads.slots.initSlot('test1');
 	assert.equal(slot.clearSlot(), true, 'a call to clear slot returns a boolean');
 	assert.ok(googletag.pubads().clear.calledOnce, 'clear api has been called');
-	assert.ok(googletag.pubads().clear.calledWith([slot.gpt.slot]), 'defaults to slot that the method has been invoked on');
+	assert.ok(
+		googletag.pubads().clear.calledWith([slot.gpt.slot]),
+		'defaults to slot that the method has been invoked on'
+	);
 });
 
 QUnit.test('provides api to clear another slot', function(assert) {
-	const slotHTML = '<div data-o-ads-name="test1" data-o-ads-formats="MediumRectangle"></div><div data-o-ads-name="test2" data-o-ads-formats="MediumRectangle"></div>';
+	const slotHTML =
+		'<div data-o-ads-name="test1" data-o-ads-formats="MediumRectangle"></div><div data-o-ads-name="test2" data-o-ads-formats="MediumRectangle"></div>';
 	this.fixturesContainer.add(slotHTML);
 	this.ads.init();
 	const slot = this.ads.slots.initSlot('test1');
@@ -270,9 +339,12 @@ QUnit.test('provides api to clear another slot', function(assert) {
 
 QUnit.test('companion service is enabled globally on slots', function(assert) {
 	this.fixturesContainer.add('<div class="o-ads" data-o-ads-name="test" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('test');
-	assert.ok(slot.gpt.slot.addService.calledWith(googletag.companionAds()), 'add companionAds service has been called on slot');
+	assert.ok(
+		slot.gpt.slot.addService.calledWith(googletag.companionAds()),
+		'add companionAds service has been called on slot'
+	);
 });
 
 QUnit.test('companion service can be switched off per format', function(assert) {
@@ -289,14 +361,22 @@ QUnit.test('companion service can be switched off per format', function(assert) 
 		}
 	});
 	const slot = this.ads.slots.initSlot('TestFormat');
-	assert.ok(slot.gpt.slot.addService.neverCalledWith(googletag.companionAds()), 'add service has not been called on format');
+	assert.ok(
+		slot.gpt.slot.addService.neverCalledWith(googletag.companionAds()),
+		'add service has not been called on format'
+	);
 });
 
 QUnit.test('companion service can be switched off per slot', function(assert) {
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
-	assert.ok(slot.gpt.slot.addService.neverCalledWith(googletag.companionAds()), 'add service has not been called on slot');
+	assert.ok(
+		slot.gpt.slot.addService.neverCalledWith(googletag.companionAds()),
+		'add service has not been called on slot'
+	);
 });
 
 QUnit.test('set unit name', function(assert) {
@@ -340,7 +420,8 @@ QUnit.test('set unit name site only', function(assert) {
 		gpt: {
 			network: '5887',
 			site: 'some-dfp-site'
-		}});
+		}
+	});
 	this.ads.slots.initSlot('unit-name-site-only');
 });
 
@@ -353,7 +434,11 @@ QUnit.test('set unit names network only', function(assert) {
 		const name = event.detail.name;
 		const slot = event.detail.slot;
 		if (name === 'unit-name-network-only') {
-			assert.strictEqual(slot.gpt.unitName, expected, 'setting unit name with empty site and empty zone  just returns network');
+			assert.strictEqual(
+				slot.gpt.unitName,
+				expected,
+				'setting unit name with empty site and empty zone  just returns network'
+			);
 			done();
 		}
 	});
@@ -367,7 +452,6 @@ QUnit.test('set unit names network only', function(assert) {
 });
 
 QUnit.test('unit names with empty strings', function(assert) {
-
 	const done = assert.async();
 	const expected = '/5887';
 	this.fixturesContainer.add(htmlstart + 'unit-name-empty-string' + htmlend);
@@ -376,7 +460,11 @@ QUnit.test('unit names with empty strings', function(assert) {
 		const name = event.detail.name;
 		const slot = event.detail.slot;
 		if (name === 'unit-name-empty-string') {
-			assert.strictEqual(slot.gpt.unitName, expected, 'setting unit name with empty string site and zone just returns network');
+			assert.strictEqual(
+				slot.gpt.unitName,
+				expected,
+				'setting unit name with empty string site and zone just returns network'
+			);
 			done();
 		}
 	});
@@ -385,7 +473,7 @@ QUnit.test('unit names with empty strings', function(assert) {
 		gpt: {
 			network: '5887',
 			site: '',
-			zone:''
+			zone: ''
 		}
 	});
 	this.ads.slots.initSlot('unit-name-empty-string');
@@ -416,7 +504,9 @@ QUnit.test('set unit name with override', function(assert) {
 QUnit.test('set unit name with attribute', function(assert) {
 	const done = assert.async();
 	const expected = '/this-works';
-	const container = this.fixturesContainer.add(htmlstart + 'unit-name-attr" data-o-ads-gpt-unit-name="' + expected + htmlend);
+	const container = this.fixturesContainer.add(
+		htmlstart + 'unit-name-attr" data-o-ads-gpt-unit-name="' + expected + htmlend
+	);
 
 	document.addEventListener('oAds.slotExpand', function(event) {
 		const name = event.detail.name;
@@ -432,28 +522,31 @@ QUnit.test('set unit name with attribute', function(assert) {
 });
 
 QUnit.test('collapse empty', function(assert) {
-
-	this.ads.init({collapseEmpty: 'after'});
+	this.ads.init({ collapseEmpty: 'after' });
 	assert.ok(googletag.pubads().collapseEmptyDivs.calledWith(false), 'after mode is set in gpt');
 	googletag.pubads().collapseEmptyDivs.reset();
 
-	this.ads.init({collapseEmpty: 'before'});
+	this.ads.init({ collapseEmpty: 'before' });
 	assert.ok(googletag.pubads().collapseEmptyDivs.calledWith(true), 'before mode is set in gpt');
 	googletag.pubads().collapseEmptyDivs.reset();
 
-	this.ads.init({collapseEmpty: 'never'});
+	this.ads.init({ collapseEmpty: 'never' });
 	assert.ok(googletag.pubads().collapseEmptyDivs.notCalled, 'never mode is set in gpt');
 });
 
 QUnit.skip('submit impression', function(assert) {
 	const infoLog = this.spy(this.utils.log, 'info');
 	const warnLog = this.spy(this.utils.log, 'warn');
-	const html = '<div data-o-ads-name="delayedimpression" data-o-ads-out-of-page="true" data-o-ads-formats="MediumRectangle"></div>';
+	const html =
+		'<div data-o-ads-name="delayedimpression" data-o-ads-out-of-page="true" data-o-ads-formats="MediumRectangle"></div>';
 	this.fixturesContainer.add(html);
 	this.ads.init();
 	const slot = this.ads.slots.initSlot('delayedimpression');
 	slot.submitGptImpression();
-	assert.ok(this.ads.utils.attach.calledWith('https://www.ft.com', true, sinon.match.any, sinon.match.any, true), 'impression url requested via utils with correct parameters');
+	assert.ok(
+		this.ads.utils.attach.calledWith('https://www.ft.com', true, sinon.match.any, sinon.match.any, true),
+		'impression url requested via utils with correct parameters'
+	);
 	assert.ok(infoLog.calledOnce, 'impression info logged');
 	assert.ok(infoLog.calledWith('Impression Url requested'), 'correct impression info logged');
 	assert.notOk(warnLog.calledOnce, 'no info notifications have been logged');
@@ -465,24 +558,34 @@ QUnit.skip('catches a failure to submit an impression', function(assert) {
 		failureCallback.call();
 	});
 	const log = this.spy(this.utils.log, 'info');
-	const html = '<div data-o-ads-name="delayedimpression" data-o-ads-out-of-page="true" data-o-ads-formats="MediumRectangle"></div>';
+	const html =
+		'<div data-o-ads-name="delayedimpression" data-o-ads-out-of-page="true" data-o-ads-formats="MediumRectangle"></div>';
 	this.fixturesContainer.add(html);
 	this.ads.init();
 	const slot = this.ads.slots.initSlot('delayedimpression');
 	slot.submitGptImpression();
 	assert.ok(attachSpy.calledWith('https://www.ft.com'), 'impression url requested via utils');
-	assert.ok(log.calledWith('CORS request to submit an impression failed'), 'message about a failed impression request is logged');
+	assert.ok(
+		log.calledWith('CORS request to submit an impression failed'),
+		'message about a failed impression request is logged'
+	);
 });
 
-QUnit.test('logs a warning when trying to submit an impression and the URL is not present within creative', function(assert) {
+QUnit.test('logs a warning when trying to submit an impression and the URL is not present within creative', function(
+	assert
+) {
 	const log = this.spy(this.utils.log, 'warn');
-	const html = '<div data-o-ads-name="delayedimpression-missing-tracking-div" data-o-ads-out-of-page="true" data-o-ads-formats="MediumRectangle"></div>';
+	const html =
+		'<div data-o-ads-name="delayedimpression-missing-tracking-div" data-o-ads-out-of-page="true" data-o-ads-formats="MediumRectangle"></div>';
 	this.fixturesContainer.add(html);
 	this.ads.init();
 	const slot = this.ads.slots.initSlot('delayedimpression-missing-tracking-div');
 	slot.submitGptImpression();
 	assert.notOk(this.ads.utils.attach.calledWith('https://www.ft.com'), 'impression url never requested via utils');
-	assert.ok(log.calledWith('Impression URL not found, this is set via a creative template.'), 'missing impression URL warning is logged');
+	assert.ok(
+		log.calledWith('Impression URL not found, this is set via a creative template.'),
+		'missing impression URL warning is logged'
+	);
 });
 
 QUnit.test('logs a warning when trying to submit an impression on a non-oop slot', function(assert) {
@@ -493,13 +596,16 @@ QUnit.test('logs a warning when trying to submit an impression on a non-oop slot
 	const slot = this.ads.slots.initSlot('delayedimpression');
 	slot.submitGptImpression();
 	assert.notOk(this.ads.utils.attach.calledWith('https://www.ft.com'), 'impression url never requested via utils');
-	assert.ok(log.calledWith('Attempting to call submitImpression on a non-oop slot'), 'catches attempt to call submit impression on a non-oop slot');
+	assert.ok(
+		log.calledWith('Attempting to call submitImpression on a non-oop slot'),
+		'catches attempt to call submit impression on a non-oop slot'
+	);
 });
 
 QUnit.test('define a basic slot', function(assert) {
 	const html = '<div data-o-ads-name="no-responsive-mpu" data-o-ads-formats="MediumRectangle"></div>';
 	this.fixturesContainer.add(html);
-	this.ads.init({responsive: false});
+	this.ads.init({ responsive: false });
 
 	this.ads.slots.initSlot('no-responsive-mpu');
 	const gptSlot = this.ads.slots['no-responsive-mpu'].gpt.slot;
@@ -529,7 +635,8 @@ QUnit.test('define responsive slot', function(assert) {
 
 QUnit.test('slotRenderStart event is fired with the correct slot name', function(assert) {
 	const done = assert.async();
-	const html = '<div data-o-ads-name="rendered-test" data-o-ads-formats="MediumRectangle" data-o-ads-targeting="pos=mid"></div>';
+	const html =
+		'<div data-o-ads-name="rendered-test" data-o-ads-formats="MediumRectangle" data-o-ads-targeting="pos=mid"></div>';
 	this.fixturesContainer.add(html);
 	this.ads.init();
 
@@ -545,8 +652,16 @@ QUnit.test('update correlator', function(assert) {
 	const errorSpy = this.spy(this.utils.log, 'warn');
 	this.ads.init();
 	this.ads.gpt.updateCorrelator();
-	assert.ok(googletag.pubads().updateCorrelator.calledOnce, 'the pub ads update correlator method is called when our method is called.');
-	assert.ok(errorSpy.calledWith('[DEPRECATED]: Updatecorrelator is being phased out by google and removed from o-ads in future releases.'), 'warns that update correlator is being deprecated');
+	assert.ok(
+		googletag.pubads().updateCorrelator.calledOnce,
+		'the pub ads update correlator method is called when our method is called.'
+	);
+	assert.ok(
+		errorSpy.calledWith(
+			'[DEPRECATED]: Updatecorrelator is being phased out by google and removed from o-ads in future releases.'
+		),
+		'warns that update correlator is being deprecated'
+	);
 });
 
 QUnit.test('fixed url for ad requests', function(assert) {
@@ -569,7 +684,6 @@ QUnit.test('fixed url for ad requests', function(assert) {
 	assert.ok(gptSlot.set.calledWith('page_url', 'http://www.random-inc.com/'), 'page url set via canonical link tag');
 });
 
-
 QUnit.test('pick up the slot URL from page address if config or canonical not available', function(assert) {
 	const urlUtilSpy = this.spy(this.utils, 'getLocation');
 	this.fixturesContainer.add('<div data-o-ads-name="url-slot" data-o-ads-formats="MediumRectangle"></div>');
@@ -577,7 +691,6 @@ QUnit.test('pick up the slot URL from page address if config or canonical not av
 	this.ads.slots.initSlot('url-slot');
 	assert.ok(urlUtilSpy.calledOnce, 'page url set via utils');
 });
-
 
 QUnit.test('creatives with size 100x100 expand the iframe to 100%', function(assert) {
 	const done = assert.async();
@@ -597,32 +710,38 @@ QUnit.test('creatives with size 100x100 expand the iframe to 100%', function(ass
 
 QUnit.test('debug returns early if no config is set', function(assert) {
 	this.ads.init();
-	const start = this.spy(this.utils.log, "start");
+	const start = this.spy(this.utils.log, 'start');
 
 	this.ads.gpt.debug();
 	assert.notOk(start.called, "`utils.start` wasn't called for 'gpt'");
 });
 
 QUnit.test('debug logs info when config is set', function(assert) {
-	this.ads.init({gpt: true});
-	const start = this.spy(this.utils.log, "start");
+	this.ads.init({ gpt: true });
+	const start = this.spy(this.utils.log, 'start');
 
 	this.ads.gpt.debug();
 	assert.ok(start.calledWith('gpt'), "`utils.start` was called for 'gpt'");
 });
 
 QUnit.test('enables companion ads', function(assert) {
-	this.ads.init({ gpt: {companions: true}});
+	this.ads.init({ gpt: { companions: true } });
 	assert.ok(googletag.pubads().disableInitialLoad.calledOnce, 'disabled the initial load');
 	assert.ok(googletag.companionAds.calledOnce, 'companion ads called');
 	assert.ok(googletag.companionAds().setRefreshUnfilledSlots.calledOnce, 'companion ads api called');
-	assert.ok(googletag.companionAds().setRefreshUnfilledSlots.calledWith(true), 'companion ads api called with correct param');
+	assert.ok(
+		googletag.companionAds().setRefreshUnfilledSlots.calledWith(true),
+		'companion ads api called with correct param'
+	);
 });
 QUnit.test('companion service is enabled globally on slots', function(assert) {
 	this.fixturesContainer.add('<div class="o-ads" data-o-ads-name="test" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('test');
-	assert.ok(slot.gpt.slot.addService.calledWith(googletag.companionAds()), 'add companionAds service has been called on slot');
+	assert.ok(
+		slot.gpt.slot.addService.calledWith(googletag.companionAds()),
+		'add companionAds service has been called on slot'
+	);
 });
 
 QUnit.test('companion service can be switched off per format', function(assert) {
@@ -639,40 +758,51 @@ QUnit.test('companion service can be switched off per format', function(assert) 
 		}
 	});
 	const slot = this.ads.slots.initSlot('TestFormat');
-	assert.ok(slot.gpt.slot.addService.neverCalledWith(googletag.companionAds()), 'add service has not been called on format');
+	assert.ok(
+		slot.gpt.slot.addService.neverCalledWith(googletag.companionAds()),
+		'add service has not been called on format'
+	);
 });
 
 QUnit.test('companion service can be switched off per slot', function(assert) {
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
-	assert.ok(slot.gpt.slot.addService.neverCalledWith(googletag.companionAds()), 'add service has not been called on slot');
+	assert.ok(
+		slot.gpt.slot.addService.neverCalledWith(googletag.companionAds()),
+		'add service has not been called on slot'
+	);
 });
 
-QUnit.test('command queue empty when googletag is available', function (assert) {
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+QUnit.test('command queue empty when googletag is available', function(assert) {
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 
 	assert.equal(window.googletag.cmd.length, 0, 'command queue empty when googletag is available');
 });
 
-
-QUnit.test('setup added to command queue when googletag not available', function (assert) {
+QUnit.test('setup added to command queue when googletag not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.ads.init({gpt: {companions: true}});
+	this.ads.init({ gpt: { companions: true } });
 	assert.equal(window.googletag.cmd.length, 1, 'setup added to command queue when googletag not available');
 	// reinstate mock
 	window.googletag = this.gpt;
 });
 
-QUnit.test('defineSlot is added to command queue when googletag is not available', function (assert) {
+QUnit.test('defineSlot is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 	const gptCommandsQueued = window.googletag.cmd.length;
 
@@ -683,12 +813,14 @@ QUnit.test('defineSlot is added to command queue when googletag is not available
 	window.googletag = this.gpt;
 });
 
-QUnit.test('clearSlot returns false when googletag is not available', function (assert) {
+QUnit.test('clearSlot returns false when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 
 	slot.clearSlot();
@@ -697,12 +829,14 @@ QUnit.test('clearSlot returns false when googletag is not available', function (
 	window.googletag = this.gpt;
 });
 
-QUnit.test('initResponsive is added to command queue when googletag is not available', function (assert) {
+QUnit.test('initResponsive is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 	const gptCommandsQueued = window.googletag.cmd.length;
 
@@ -713,12 +847,14 @@ QUnit.test('initResponsive is added to command queue when googletag is not avail
 	window.googletag = this.gpt;
 });
 
-QUnit.test('display is added to command queue when googletag is not available', function (assert) {
+QUnit.test('display is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 	const gptCommandsQueued = window.googletag.cmd.length;
 
@@ -729,12 +865,14 @@ QUnit.test('display is added to command queue when googletag is not available', 
 	window.googletag = this.gpt;
 });
 
-QUnit.test('setUnitName is added to command queue when googletag is not available', function (assert) {
+QUnit.test('setUnitName is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 	const gptCommandsQueued = window.googletag.cmd.length;
 
@@ -745,12 +883,14 @@ QUnit.test('setUnitName is added to command queue when googletag is not availabl
 	window.googletag = this.gpt;
 });
 
-QUnit.test('addServices is added to command queue when googletag is not available', function (assert) {
+QUnit.test('addServices is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 	const gptCommandsQueued = window.googletag.cmd.length;
 
@@ -761,12 +901,14 @@ QUnit.test('addServices is added to command queue when googletag is not availabl
 	window.googletag = this.gpt;
 });
 
-QUnit.test('setCollapseEmpty is added to command queue when googletag is not available', function (assert) {
+QUnit.test('setCollapseEmpty is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 	const gptCommandsQueued = window.googletag.cmd.length;
 
@@ -776,12 +918,14 @@ QUnit.test('setCollapseEmpty is added to command queue when googletag is not ava
 	window.googletag = this.gpt;
 });
 
-QUnit.test('setURL is added to command queue when googletag is not available', function (assert) {
+QUnit.test('setURL is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 	const gptCommandsQueued = window.googletag.cmd.length;
 
@@ -791,12 +935,14 @@ QUnit.test('setURL is added to command queue when googletag is not available', f
 	window.googletag = this.gpt;
 });
 
-QUnit.test('setTargeting is added to command queue when googletag is not available', function (assert) {
+QUnit.test('setTargeting is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 	const gptCommandsQueued = window.googletag.cmd.length;
 
@@ -806,12 +952,14 @@ QUnit.test('setTargeting is added to command queue when googletag is not availab
 	window.googletag = this.gpt;
 });
 
-QUnit.test('updateCorrelator is added to command queue when googletag is not available', function (assert) {
+QUnit.test('updateCorrelator is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const gptCommandsQueued = window.googletag.cmd.length;
 
 	this.ads.gpt.updateCorrelator();
@@ -826,15 +974,20 @@ QUnit.test('clear slot method calls to the ad server providers clear function', 
 	this.ads.init();
 	const slot = this.ads.slots.initSlot(node);
 	slot.clearSlot();
-	assert.ok(googletag.pubads().clear.calledWith([slot.gpt.slot]), 'googletag clear method called with the correct slot');
+	assert.ok(
+		googletag.pubads().clear.calledWith([slot.gpt.slot]),
+		'googletag clear method called with the correct slot'
+	);
 });
 
 QUnit.test('onRefresh is added to command queue when googletag is not available', function(assert) {
 	// delete the mock for this test
 	delete window.googletag;
 
-	this.fixturesContainer.add('<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>');
-	this.ads.init({gpt: {companions: true}});
+	this.fixturesContainer.add(
+		'<div class="o-ads" data-o-ads-companion="false" data-o-ads-name="TestFormat" data-o-ads-formats="MediumRectangle"></div>'
+	);
+	this.ads.init({ gpt: { companions: true } });
 	const slot = this.ads.slots.initSlot('TestFormat');
 	const gptCommandsQueued = window.googletag.cmd.length;
 
@@ -846,13 +999,19 @@ QUnit.test('onRefresh is added to command queue when googletag is not available'
 });
 
 QUnit.test('nonPersonalized request mode', function(assert) {
-	this.ads.init({gpt: true});
-	assert.ok(googletag.pubads().setRequestNonPersonalizedAds.calledWith(1), 'nonPersonalized request mode initialised when programmatic consent has not been given');
+	this.ads.init({ gpt: true });
+	assert.ok(
+		googletag.pubads().setRequestNonPersonalizedAds.calledWith(1),
+		'nonPersonalized request mode initialised when programmatic consent has not been given'
+	);
 });
 
 QUnit.test('nonPersonalized request mode', function(assert) {
 	document.cookie = 'FTConsent=behaviouraladsOnsite%3Aoff%2CprogrammaticadsOnsite%3Aon;';
-	this.ads.init({gpt: true});
-	assert.ok(googletag.pubads().setRequestNonPersonalizedAds.calledWith(0), 'nonPersonalized request mode disabled (called with "0") when programmatic consent given.');
+	this.ads.init({ gpt: true });
+	assert.ok(
+		googletag.pubads().setRequestNonPersonalizedAds.calledWith(0),
+		'nonPersonalized request mode disabled (called with "0") when programmatic consent given.'
+	);
 	this.deleteCookie('FTConsent');
 });

--- a/test/qunit/targeting.test.js
+++ b/test/qunit/targeting.test.js
@@ -2,8 +2,7 @@
 
 'use strict'; //eslint-disable-line
 
-QUnit.module('Targeting', {
-});
+QUnit.module('Targeting', {});
 
 QUnit.test('getFromConfig', function(assert) {
 	this.ads.init({});
@@ -15,13 +14,11 @@ QUnit.test('getFromConfig', function(assert) {
 	result = this.ads.targeting.get();
 	assert.deepEqual(Object.keys(result).length, 2, 'Empty string dfp_targeting returns only default params');
 
-
 	this.ads.targeting.clear();
 	this.ads.config('dfp_targeting', 'some=test;targeting=params');
 	result = this.ads.targeting.get();
 	assert.deepEqual(result.some, 'test', 'Simple params are parsed correctly');
 	assert.deepEqual(result.targeting, 'params', 'Simple params are parsed correctly');
-
 
 	this.ads.targeting.clear();
 	this.ads.config('dfp_targeting', 'some=test;;targeting=params');
@@ -30,14 +27,14 @@ QUnit.test('getFromConfig', function(assert) {
 	assert.deepEqual(result.targeting, 'params', 'Double ; are handled');
 
 	this.ads.targeting.clear();
-	this.ads.config('dfp_targeting', 's@me=test;targeting=par@ms$\'');
+	this.ads.config('dfp_targeting', "s@me=test;targeting=par@ms$'");
 	result = this.ads.targeting.get();
 
 	assert.deepEqual(result['s@me'], 'test', 'Special characters in targeting key handled');
-	assert.deepEqual(result.targeting, 'par@ms$\'', 'Special characters in targeting value handled');
+	assert.deepEqual(result.targeting, "par@ms$'", 'Special characters in targeting value handled');
 });
 
-QUnit.test("OADS_VERSION is set to value set in config", function(assert) {
+QUnit.test('OADS_VERSION is set to value set in config', function(assert) {
 	const getVersion = this.stub(this.ads.utils, 'getVersion');
 	getVersion.returns('x.y.z');
 
@@ -45,7 +42,11 @@ QUnit.test("OADS_VERSION is set to value set in config", function(assert) {
 
 	const result = this.ads.targeting.get();
 	assert.ok(getVersion.called, 'utils.getVersion() should be called');
-	assert.equal(result.OADS_VERSION, `x.y.z`, 'OADS_VERSION targeting parameter should be present if passOAdsVersion is set to true');
+	assert.equal(
+		result.OADS_VERSION,
+		`x.y.z`,
+		'OADS_VERSION targeting parameter should be present if passOAdsVersion is set to true'
+	);
 });
 
 QUnit.test('OADS_VERSION is not set if the flag is set to false', function(assert) {
@@ -55,7 +56,11 @@ QUnit.test('OADS_VERSION is not set if the flag is set to false', function(asser
 
 	const result = this.ads.targeting.get();
 	assert.notOk(getVersion.called, 'utils.getVersion() should not be called');
-	assert.equal(result.OADS_VERSION, undefined , 'OADS_VERSION parameter should not be present when passOAdsVersion is set to false');
+	assert.equal(
+		result.OADS_VERSION,
+		undefined,
+		'OADS_VERSION parameter should not be present when passOAdsVersion is set to false'
+	);
 });
 
 QUnit.test('OADS_VERSION is not set if not provided in config', function(assert) {
@@ -65,155 +70,59 @@ QUnit.test('OADS_VERSION is not set if not provided in config', function(assert)
 
 	const result = this.ads.targeting.get();
 	assert.notOk(getVersion.called, 'utils.getVersion() should not be called');
-	assert.equal(result.OADS_VERSION, undefined , 'OADS_VERSION parameter should not be present when passOAdsVersion is not set');
+	assert.equal(
+		result.OADS_VERSION,
+		undefined,
+		'OADS_VERSION parameter should not be present when passOAdsVersion is not set'
+	);
 });
 
 QUnit.test('socialflow parameter', function(assert) {
-	this.stub(this.ads.utils, 'getQueryParamByName').returns("ohheey");
-	assert.deepEqual(this.ads.targeting.socialFlow(), { socialflow: 'ohheey'});
+	this.stub(this.ads.utils, 'getQueryParamByName').returns('ohheey');
+	assert.deepEqual(this.ads.targeting.socialFlow(), { socialflow: 'ohheey' });
 });
 
-QUnit.test("social referrer", function(assert) {
+QUnit.test('social referrer', function(assert) {
 	let result;
 	const referrer = this.stub(this.ads.utils, 'getReferrer');
 
 	referrer.returns('');
 	this.ads.init({ socialReferrer: true });
 	result = this.ads.targeting.get();
-	assert.equal(result.socref, undefined, "No document referrer, socref key returns undefined");
+	assert.equal(result.socref, undefined, 'No document referrer, socref key returns undefined');
 
 	referrer.returns('http://t.co/cjPOFshzk2');
 	this.ads.init({ socialReferrer: true });
 	result = this.ads.targeting.get();
-	assert.equal(result.socref, "twi", "Already logged in, twitter should be mapped from t.co to twi");
+	assert.equal(result.socref, 'twi', 'Already logged in, twitter should be mapped from t.co to twi');
 
 	referrer.returns('http://www.facebook.com/l.php?');
 	this.ads.init({ socialReferrer: true });
 	result = this.ads.targeting.get();
-	assert.equal(result.socref, "fac", "Already logged in, facebook should be mapped from facebook.com to fac");
+	assert.equal(result.socref, 'fac', 'Already logged in, facebook should be mapped from facebook.com to fac');
 
 	referrer.returns('http://www.linkedin.com/company/4697?trk=NUS-body-company-name');
 	this.ads.init({ socialReferrer: true });
 	result = this.ads.targeting.get();
-	assert.equal(result.socref, "lin", "Already logged in, linkedin should be mapped from linkedin.com to lin");
+	assert.equal(result.socref, 'lin', 'Already logged in, linkedin should be mapped from linkedin.com to lin');
 
 	referrer.returns('http://www.drudgereport.com/');
 	this.ads.init({ socialReferrer: true });
 	result = this.ads.targeting.get();
-	assert.equal(result.socref, "dru", "Already logged in, drudge should be mapped from drudgereport.com to dru");
+	assert.equal(result.socref, 'dru', 'Already logged in, drudge should be mapped from drudgereport.com to dru');
 
 	referrer.returns('http://dianomi.com');
 	this.ads.init({ socialReferrer: true });
 	result = this.ads.targeting.get();
-	assert.equal(result.socref, "dia", "Already logged in, drudge should be mapped from dianomi.com to dia");
+	assert.equal(result.socref, 'dia', 'Already logged in, drudge should be mapped from dianomi.com to dia');
 
 	referrer.returns('http://google.com/');
 	this.ads.init({ socialReferrer: true });
 	result = this.ads.targeting.get();
-	assert.equal(result.socref, "goo", "Already logged in, drudge should be mapped from google.com to goo");
+	assert.equal(result.socref, 'goo', 'Already logged in, drudge should be mapped from google.com to goo');
 });
 
-QUnit.test("search term", function(assert) {
-	let result;
-	const querystring = this.stub(this.ads.utils, 'getQueryString');
-
-	querystring.returns();
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, undefined, "no query string, kw param should be undefined");
-
-	querystring.returns('q=  this  is  ');
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "this is", "excess space removed");
-
-	querystring.returns('q=  this  is  ');
-	this.ads.init();
-	result = this.ads.targeting.get('  THIS  IS  ');
-	assert.equal(result.kw, "this is", "lowercased");
-
-	querystring.returns("q= ^ this+is 'it' ; ");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "this is it", "DFP restricted characters removed");
-
-	querystring.returns("q= %5E this%2Bis %27it%27 %3B %20 ");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "this is it", "DFP restricted characters removed even if escaped");
-
-	querystring.returns("q=  this.is%2Eit");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "this.is.it", "full-stop escaped as it means something to DFP");
-
-	querystring.returns("q=`!\"_%26$%^*_()_+-_={}[]_:@~ '_#<>?,_./|\\");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "`!\"_&$% *_()_ -_={}[]_:@~ _#<>?,_./|\\", "remaining punctuation encoded");
-
-	querystring.returns("q=uk:PSON");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "uk:pson", "uk:PSON from tearsheet");
-
-	querystring.returns("q=PSON.GB%3APLU");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "pson.gb:plu", "PSON.GB:PLU from tearsheet");
-
-	querystring.returns("searchField=power%20my%20world&null=&termId=");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "power my world", "lexicon: searchField in URL");
-
-	querystring.returns("q=rock+my+world");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "rock my world", "alphaville: q in URL");
-
-	querystring.returns("s=uk:PSON");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "uk:pson", "tearsheet uk:PSON: query in URL");
-
-	querystring.returns("s=PSON.GB%3APLU&vsc_appId=ts&ftsite=FTCOM&searchtype=equity");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "pson.gb:plu", "tearsheet PSON.GB:PLU: query in URL");
-
-	querystring.returns("s=PSON%3ALSE&vsc_appId=ts&ftsite=FTCOM&searchtype=equity");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "pson:lse", "tearsheet PSON:LSE: query in URL");
-
-	querystring.returns("view=company&time=123837238384&selectedResultGroup=&query=pearson&country=&issueType=");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "pearson", "search on markets quoted string: query in URL");
-
-	querystring.returns("query=rock%20my%20world");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "rock my world", "search on markets quoted string: query in URL");
-
-	querystring.returns("queryText=rock+my+world&x=0&y=0&aje=true&dse=&dsz=");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "rock my world", "search from articles/video: queryText in URL");
-
-	querystring.returns("queryText=rock+my+world&ftsearchType=type_news");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "rock my world", "search from home page, etc: queryText in URL");
-
-	querystring.returns("queryText=rock+my+world");
-	this.ads.init();
-	result = this.ads.targeting.get();
-	assert.equal(result.kw, "rock my world", "search: queryText in URL");
-});
-
-QUnit.test("timestamp", function(assert) {
+QUnit.test('timestamp', function(assert) {
 	// AF: The function that sets result.ts (under test here) uses `new Date()`
 	// so we need to use the same here. Using Date.UTC() will not work if
 	// you're not in UTC timezone. Found out the hard way!
@@ -221,38 +130,35 @@ QUnit.test("timestamp", function(assert) {
 	const clock = this.date(curTime.valueOf());
 	this.ads.init({ timestamp: true });
 	let result = this.ads.targeting.get();
-	assert.equal(result.ts, '20131118233007', "timestamp value returns correctly");
+	assert.equal(result.ts, '20131118233007', 'timestamp value returns correctly');
 
 	// Fast forward one hour
 	clock.tick(3600000);
 	result = this.ads.targeting.get();
-	assert.equal(result.ts, '20131119003007', "fast forward one hour and timestamp value returns correctly");
+	assert.equal(result.ts, '20131119003007', 'fast forward one hour and timestamp value returns correctly');
 });
 
-QUnit.test("responsive", function(assert) {
-
+QUnit.test('responsive', function(assert) {
 	const breakpoint = this.stub(this.ads.utils.responsive, 'getCurrent');
-	breakpoint.returns("small");
-	this.ads.init({responsive: [] });
+	breakpoint.returns('small');
+	this.ads.init({ responsive: [] });
 	const result = this.ads.targeting.get();
 
 	assert.equal(result.res, 'small');
 });
 
-QUnit.test("Responsive targeting on non-responsive page", function(assert) {
-
+QUnit.test('Responsive targeting on non-responsive page', function(assert) {
 	const breakpoint = this.stub(this.ads.utils.responsive, 'getCurrent');
-	breakpoint.returns("small");
-	this.ads.init({responsive: false});
+	breakpoint.returns('small');
+	this.ads.init({ responsive: false });
 	const result = this.ads.targeting.get();
 
 	assert.equal(result.hasOwnProperty('res'), false);
 });
 
-
 QUnit.test('debug starts logging data', function(assert) {
-	this.ads.init({dfp_targeting: {data: {allOfThe: 'targeting data'}}});
-	const start = this.spy(this.utils.log, "start");
+	this.ads.init({ dfp_targeting: { data: { allOfThe: 'targeting data' } } });
+	const start = this.spy(this.utils.log, 'start');
 
 	this.ads.targeting.debug();
 	assert.ok(start.called, "`utils.start` was called for 'targeting'");


### PR DESCRIPTION
Currently targeting requests include all parameters in the referring URL, including potentially sensitive information such as search terms

This PR adds a new utility method `stripUrlParams` which removes a configurable list of parameters from the main body of the URL and from named nested parameters.

Additional CI-related features:
- Performance: adding the ` --production` flag to `obt build` reduces the output from 105Kb to 13Kb
- Pre-commit tasks: `npx obt verify` has been added to prevent linting issues failing the build
- Code coverage: Karma is no longer part of the `test-unit` task to prevent coverage issues failing the build

Additional miscellaneous features
- Prettier config added to ensure conformance with code style coventions