### PR TITLE
Add renovate bot to keep dependencies up to date

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>financial-times/renovate-config-next"]
+}


### PR DESCRIPTION
This PR adds the recommended config for Renovate Bot to do its thing now that it has been added to the [list of installed apps](https://github.com/Financial-Times/o-ads/settings/installations)