### PR TITLE
Clear page targeting separately

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -517,14 +517,20 @@ function updateCorrelator() {
 	});
 }
 
+function clearPageTargeting() {
+	if (window.googletag) {
+		googletag.cmd.push(() => {
+			googletag.pubads().clearTargeting();
+		});
+	}
+	else {
+		utils.log.warn('Attempting to clear page targeting before the GPT library has initialized');
+	}
+}
+
 function updatePageTargeting(override) {
 	if (window.googletag) {
 		const params = utils.isPlainObject(override) ? override : targeting.get();
-		if (!override) {
-			googletag.cmd.push(() => {
-				googletag.pubads().clearTargeting();
-			});
-		}
 		setPageTargeting(params);
 	} else {
 		utils.log.warn('Attempting to set page targeting before the GPT library has initialized');
@@ -556,6 +562,7 @@ export default {
 	setup,
 	updateCorrelator,
 	updatePageTargeting,
+	clearPageTargeting,
 	clearPageTargetingForKey,
 	hasGPTLoaded,
 	loadGPT,


### PR DESCRIPTION
The oAds.gpt.updatePageTargeting() function clears any targeting parameters previously set. This is a problem, because in the case of brandmetrics on the app, they are setting a parameter directly on the global window.googletag object, before we are calling updatePageTargeting() , and hence it removes it. My solution would be to not clear the targeting inside updatePageTargeting() but instead create a function clearPageTargeting() and call this explicitly wherever needed.