### PR TITLE
Removing feature for GDPR compliance, search-key-words will no longer…

### DIFF
--- a/src/js/targeting.js
+++ b/src/js/targeting.js
@@ -12,7 +12,6 @@ Targeting.prototype.get = function() {
 	utils.extend(
 		parameters,
 		this.getFromConfig(),
-		this.searchTerm(),
 		this.socialFlow(),
 		this.getVersion()
 	);


### PR DESCRIPTION
Removing feature for GDPR compliance, search-key-words will no longer be passed into custom-targeting by default.

O-ads has a public method `oAds.targeting.searchTerm()` - this is a util method for extracting search key-words from standard search forms. It may be that we want to remove this feature completely from o-ads; however for the short term we are ensuring that the function is not called by default.