### PR TITLE
Fix secret-squirrel complaining about CODEOWNERS

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -18,7 +18,8 @@ module.exports = {
 			'docs/Gemfile.lock',
 			'docs/_posts/2016-08-19-welcome-to-jekyll.markdown',
 			'main.mustache',
-			'package-lock.json'
+			'package-lock.json',
+			'.github/CODEOWNERS'
 		],
 		allowOverrides: []
 	},


### PR DESCRIPTION
A code CODEOWNERS  has been recently added to this repo. However, that makes `git push` fail as secret-squirrel complains about that file. 

This fixes it similarly to what's been done in other places.