### PR TITLE
ADSDEV-394: Enable callback for additional targeting handling

### DIFF
--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -57,6 +57,16 @@ Api.prototype.handleResponse = function(response) {
 		}
 	}
 
+	// TO-DO: This enables setting additional `cust_params` outside `o-ads` based on
+	// the same API responses. That basically empowers the consuming app to
+	// use it's own complex serialising logic without needing to touch `o-ads`.
+	if (typeof this.config.apiResponseHandler === 'function') {
+		const additionalTargeting = this.config.apiResponseHandler(response);
+		if (additionalTargeting && typeof additionalTargeting === 'object') {
+			this.instance.targeting.add(additionalTargeting);
+		}
+	}
+
 	return response;
 };
 

--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -57,7 +57,7 @@ Api.prototype.handleResponse = function(response) {
 		}
 	}
 
-	// TO-DO: This enables setting additional `cust_params` outside `o-ads` based on
+	// This enables setting additional `cust_params` outside `o-ads` based on
 	// the same API responses. That basically empowers the consuming app to
 	// use it's own complex serialising logic without needing to touch `o-ads`.
 	if (typeof this.config.apiResponseHandler === 'function') {


### PR DESCRIPTION
This change enables adding additional `cust_params` by passing the api responses to an external method received in `o-ads`' configuration which can return an object whose key-value collection will be used for the additional targeting.

By using this approach API targeting marshalling can be done outside `o-ads` which has some benefits like de-coupling `o-ads` from app-specific logic, which allows us not to expose FT-specific logic in this repo (including feature flags, etc.. ).

It's worth noticing that:

1.  If `this.config.apiResponseHandler` doesn't contain a function, no new logic will be executed by `o-ads`
2. If `this.config.apiResponseHandler` returns `null` or `undefined`, no new logic will be executed by `o-ads` 
3. I have this working in conjunction with `n-ads` locally for implementing ADSDEV-394 and it works well.

