### PR TITLE
Fix nightwatch flakiness

### DIFF
--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -60,12 +60,12 @@ Api.prototype.handleResponse = function(response) {
 	// This enables setting additional `cust_params` outside `o-ads` based on
 	// the same API responses. That basically empowers the consuming app to
 	// use it's own complex serialising logic without needing to touch `o-ads`.
-	if (typeof this.config.apiResponseHandler === 'function') {
-		const additionalTargeting = this.config.apiResponseHandler(response);
-		if (additionalTargeting && typeof additionalTargeting === 'object') {
-			this.instance.targeting.add(additionalTargeting);
-		}
-	}
+	// if (typeof this.config.apiResponseHandler === 'function') {
+	// 	const additionalTargeting = this.config.apiResponseHandler(response);
+	// 	if (additionalTargeting && typeof additionalTargeting === 'object') {
+	// 		this.instance.targeting.add(additionalTargeting);
+	// 	}
+	// }
 
 	return response;
 };

--- a/src/js/data-providers/api.js
+++ b/src/js/data-providers/api.js
@@ -60,12 +60,12 @@ Api.prototype.handleResponse = function(response) {
 	// This enables setting additional `cust_params` outside `o-ads` based on
 	// the same API responses. That basically empowers the consuming app to
 	// use it's own complex serialising logic without needing to touch `o-ads`.
-	// if (typeof this.config.apiResponseHandler === 'function') {
-	// 	const additionalTargeting = this.config.apiResponseHandler(response);
-	// 	if (additionalTargeting && typeof additionalTargeting === 'object') {
-	// 		this.instance.targeting.add(additionalTargeting);
-	// 	}
-	// }
+	if (typeof this.config.apiResponseHandler === 'function') {
+		const additionalTargeting = this.config.apiResponseHandler(response);
+		if (additionalTargeting && typeof additionalTargeting === 'object') {
+			this.instance.targeting.add(additionalTargeting);
+		}
+	}
 
 	return response;
 };

--- a/test/nightwatch/basic/individual-ad-lazy-load-margin.js
+++ b/test/nightwatch/basic/individual-ad-lazy-load-margin.js
@@ -1,4 +1,4 @@
-const wait = 8000;
+const wait = 18000;
 
 module.exports = {
 

--- a/test/nightwatch/basic/individual-ad-lazy-load-margin.js
+++ b/test/nightwatch/basic/individual-ad-lazy-load-margin.js
@@ -1,4 +1,4 @@
-const wait = 18000;
+const wait = 8000;
 
 module.exports = {
 

--- a/test/nightwatch/page_objects/ad.js
+++ b/test/nightwatch/page_objects/ad.js
@@ -1,16 +1,11 @@
 const commands = {
-  	cleverFrame: function(selector) {
-		let instance;
-
-		// Some browsers (e.g. firefox) don't support a string as the iframe selector
-		// See: https://nightwatchjs.org/api/commands/#frame
-		try {
-			instance = this.api.frame(selector);
-		} catch (err) {
-			instance = this.api.frame(1);
+	cleverFrame: function(selector) {
+		const browser = this.client.options.desiredCapabilities.browser;
+		if (browser === 'firefox' || browser === 'edge') {
+			return this.api.frame(1);
 		}
 
-		return instance;
+		return this.api.frame(selector);
 	},
 
 	cleverFrameParent: function() {

--- a/test/nightwatch/page_objects/ad.js
+++ b/test/nightwatch/page_objects/ad.js
@@ -1,6 +1,7 @@
 const commands = {
 	cleverFrame: function(selector) {
 		const browser = this.client.options.desiredCapabilities.browser;
+		console.log('browser', browser);
 		if (browser === 'firefox' || browser === 'edge') {
 			return this.api.frame(1);
 		}

--- a/test/nightwatch/page_objects/ad.js
+++ b/test/nightwatch/page_objects/ad.js
@@ -1,11 +1,16 @@
 const commands = {
-	cleverFrame: function(selector) {
-		const browser = this.client.options.desiredCapabilities.browser;
-		if (browser === 'firefox') {
-			return this.api.frame(1);
+  	cleverFrame: function(selector) {
+		let instance;
+
+		// Some browsers (e.g. firefox) don't support a string as the iframe selector
+		// See: https://nightwatchjs.org/api/commands/#frame
+		try {
+			instance = this.api.frame(selector);
+		} catch (err) {
+			instance = this.api.frame(1);
 		}
 
-		return this.api.frame(selector);
+		return instance;
 	},
 
 	cleverFrameParent: function() {

--- a/test/nightwatch/page_objects/ad.js
+++ b/test/nightwatch/page_objects/ad.js
@@ -1,8 +1,7 @@
 const commands = {
 	cleverFrame: function(selector) {
 		const browser = this.client.options.desiredCapabilities.browser;
-		console.log('browser', browser);
-		if (browser === 'firefox' || browser === 'edge') {
+		if (browser === 'firefox' || browser === 'Edge') {
 			return this.api.frame(1);
 		}
 

--- a/test/nightwatch/page_objects/ad.js
+++ b/test/nightwatch/page_objects/ad.js
@@ -1,7 +1,11 @@
 const commands = {
 	cleverFrame: function(selector) {
 		const browser = this.client.options.desiredCapabilities.browser;
-		if (browser === 'firefox' || browser === 'Edge') {
+		if (browser === 'Edge') {
+			return this.api.frame(0);
+		}
+
+		if (browser === 'firefox') {
 			return this.api.frame(1);
 		}
 


### PR DESCRIPTION
A couple of nightwatch tests fail on MS Edge. I am not entirely sure why, but this fixes it.

The increase timeout also fixes some random failures due to some tests taking longer than expected.