### PR TITLE
Install the dependencies required for cypress to work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       # Install dependencies for cypress -- https://docs.cypress.io/guides/guides/continuous-integration.html#Ubuntu-Debian
-      - run: apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+      - run: sudo apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - run: npm config set prefix "$HOME/.local"
       - run: npm i -g origami-build-tools@^9
       - run: $HOME/.local/bin/obt install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ jobs:
       - image: circleci/node:10-browsers
     steps:
       - checkout
+      # Install dependencies for cypress -- https://docs.cypress.io/guides/guides/continuous-integration.html#Ubuntu-Debian
+      - run: apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - run: npm config set prefix "$HOME/.local"
       - run: npm i -g origami-build-tools@^9
       - run: $HOME/.local/bin/obt install


### PR DESCRIPTION
Currently cypress fails to run on CircleCI due to missing dependencies, I've added a run command to install all the dependencies Cypress requires.