### PR TITLE
ADSDEV-469 Do not run gpt's enableLazyLoad routine when flag not provided

### DIFF
--- a/src/js/ad-servers/gpt.js
+++ b/src/js/ad-servers/gpt.js
@@ -83,7 +83,10 @@ function setup(gptConfig) {
 	setRenderingMode(gptConfig);
 	setPageTargeting(targeting.get());
 	setPageCollapseEmpty();
-	enableLazyLoad(gptConfig.enableLazyLoad);
+
+	if (gptConfig.hasOwnProperty('enableLazyLoad')) {
+		enableLazyLoad(gptConfig.enableLazyLoad);
+	}
 
 	const url = stripUrlParams({
 		href: window.location.href,

--- a/src/js/slot.js
+++ b/src/js/slot.js
@@ -314,7 +314,7 @@ Slot.prototype.maximise = function(size) {
 Slot.prototype.setName = function() {
 	this.name = this.container.getAttribute('data-o-ads-name') || this.container.getAttribute('o-ads-name');
 	if (!this.name) {
-		this.name = `o-ads-slot-${(Math.floor(Math.random() * 10000))}`;
+		this.name = `o-ads-slot-${Math.floor(Math.random() * 10000)}`;
 		this.container.setAttribute('data-o-ads-name', this.name);
 	}
 	return this;

--- a/test/jest/gpt.js
+++ b/test/jest/gpt.js
@@ -30,7 +30,14 @@ describe('setup', () => {
 
 	describe('enableLazyLoad()', () => {
 
-		test('should explicitly disable lazy load', () => {
+		test('should implicitly disable lazy load, if option not provided', () => {
+			gpt.setup({});
+
+			expect(global.googletag.pubads().enableLazyLoad)
+				.not.toBeCalled();
+		});
+
+		test('should explicitly disable lazy load, if false', () => {
 			gpt.setup({
 				enableLazyLoad: false,
 			});
@@ -63,8 +70,21 @@ describe('setup', () => {
 				);
 		});
 
-		test('should not enable lazy load, if lazyLoadCong is not a boolean or an object', () => {
+		test('should not enable lazy load, if lazyLoadConf is not a boolean or an object', () => {
 			const enableLazyLoad = 'what';
+			const spyConsoleWarn = jest.spyOn(log, 'warn');
+
+			gpt.setup({ enableLazyLoad });
+
+			expect(spyConsoleWarn).toBeCalledWith('lazyLoadConf must be either an object or a boolean', enableLazyLoad);
+			expect(global.googletag.pubads().enableLazyLoad)
+				.not.toBeCalled();
+
+			spyConsoleWarn.mockReset();
+		});
+
+		test('should not enable lazy load, if lazyLoadConf is null', () => {
+			const enableLazyLoad = null;
 			const spyConsoleWarn = jest.spyOn(log, 'warn');
 
 			gpt.setup({ enableLazyLoad });

--- a/test/jest/gpt.js
+++ b/test/jest/gpt.js
@@ -30,7 +30,7 @@ describe('setup', () => {
 
 	describe('enableLazyLoad()', () => {
 
-		test('should implicitly disable lazy load, if option not provided', () => {
+		test('should disable lazy loading, if the "enableLazyLoad" option is not provided', () => {
 			gpt.setup({});
 
 			expect(global.googletag.pubads().enableLazyLoad)

--- a/test/jest/gpt.js
+++ b/test/jest/gpt.js
@@ -70,7 +70,7 @@ describe('setup', () => {
 				);
 		});
 
-		test('should not enable lazy load, if lazyLoadConf is not a boolean or an object', () => {
+		test('should not enable lazy load, if "enableLazyLoad" is not a boolean or an object', () => {
 			const enableLazyLoad = 'what';
 			const spyConsoleWarn = jest.spyOn(log, 'warn');
 

--- a/test/jest/testUtils/pMark.js
+++ b/test/jest/testUtils/pMark.js
@@ -4,7 +4,7 @@ export const mark = markName => {
 	perfmarks.push({
 		type: 'mark',
 		name: markName,
-		startTime: (new Date()).getMilliseconds()
+		startTime: new Date().getMilliseconds()
 	});
 };
 

--- a/test/qunit/gpt.test.js
+++ b/test/qunit/gpt.test.js
@@ -188,6 +188,11 @@ QUnit.test('not enabled gpt lazy load with invalid custom params', function(asse
 	assert.ok(googletag.pubads().enableLazyLoad.notCalled, 'enable gpt lazy load not called');
 });
 
+QUnit.test('not enabled gpt lazy load if gpt option not provided', function(assert) {
+	this.ads.init({ gpt: {} });
+	assert.ok(googletag.pubads().enableLazyLoad.notCalled, 'enable gpt lazy load not called');
+});
+
 QUnit.test('enables companion ads', function(assert) {
 	this.ads.init({ gpt: { companions: true } });
 	assert.ok(googletag.pubads().disableInitialLoad.calledOnce, 'disabled the initial load');

--- a/test/qunit/setup.test.js
+++ b/test/qunit/setup.test.js
@@ -35,9 +35,9 @@ QUnit.test('Basic Sinon methods are available via this', function(assert) {
 
 QUnit.test('Sinon fake timers are available', function(assert) {
 	const clock = this.date(1);
-	assert.equal((new Date()).valueOf(), 1, 'the date object is now mocked');
+	assert.equal(new Date().valueOf(), 1, 'the date object is now mocked');
 	clock.tick(1);
-	assert.equal((new Date()).valueOf(), 2, 'a tick of the clock now pushes the date forward');
+	assert.equal(new Date().valueOf(), 2, 'a tick of the clock now pushes the date forward');
 });
 
 const _XMLHttpRequest = window.XMLHttpRequest;


### PR DESCRIPTION
## Description
Noticed that when `enableLazyLoad` flag is not provided - meaning is not included in the gpt's options passed to o-ads - the routine `gpt.enableLazyLoad` is executed anyway.

This causes `gpt.enableLazyLoad` to warn the user that the config object is not compliant - as it expects either an object or a boolean.

## Acceptance
`gpt.enableLazyLoad` is not executed if the flag is not provided.