### PR TITLE
WIP: Fixing imports for the utils sub-module and explicitly initialising …

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,7 +1,7 @@
 import ads from './../../main';
 
 
-// document.addEventListener("DOMContentLoaded", function() {
-// 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-// });
+document.addEventListener("DOMContentLoaded", function() {
+	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+});
 ads.initAll();

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,5 +1,7 @@
-window.oads = require('../..');
+import ads from './../../main';
 
-document.addEventListener("DOMContentLoaded", function() {
-	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-});
+
+// document.addEventListener("DOMContentLoaded", function() {
+// 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+// });
+ads.initAll();

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -4,4 +4,3 @@ import ads from './../../main';
 document.addEventListener("DOMContentLoaded", function() {
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });
-ads.initAll();

--- a/src/js/utils/metrics.js
+++ b/src/js/utils/metrics.js
@@ -1,4 +1,4 @@
-import utils from './index';
+import * as utils from './index';
 
 function getMarksForEvents(events, suffix) {
 	const markNames = events.map( eventName => 'oAds.' + eventName + suffix );

--- a/src/js/utils/responsive.js
+++ b/src/js/utils/responsive.js
@@ -1,7 +1,7 @@
 let callback;
 let breakpoints;
 let current;
-import utils from './index';
+import * as utils from './index';
 import oViewport from 'o-viewport';
 
 function getNearestBreakpoint() {


### PR DESCRIPTION
Fixing imports for the utils sub-module and explicitly initialising demos.

The Origami demos were not being built correctly - this seemed due to a few issues with how modules were being imported.

 > `require` has been changed to `import` in demo.js`
 > the `utils` module appeared to be making incorrect use of 'import' 
 > Demos were not initialising consistently; i have called `ads.initAll()` explicitly in demo.js, rather than use the domContentLoaded event.

