### PR TITLE
Remove nightwatch, cypress and pupeteer tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,21 +15,6 @@ jobs:
       - run: npm run checksizes
       # `obt test` doesn't work because of custom karma config, so we run:
       - run: npm run test-unit
-      - run: wget https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip && unzip ./BrowserStackLocal-linux-x64.zip
-      - run:
-          command: npm run demo-server
-          background: true
-      - run: npm run test-cy:run
-      - run: npm run test-e2e
-      - run:
-          command: ./BrowserStackLocal --key=$BROWSERSTACK_KEY
-          background: true
-      - run: sleep 5 && wget -qO- --retry-connrefused --no-check-certificate -T 60 http://localhost:3002
-      - run: npm run test-nw
-      - store_artifacts:
-          path: test/cypress/videos
-      - store_artifacts:
-          path: test/cypress/screenshots
 
       # We need to delete bower stuff and check that the package works on npm only
       - run: rm -rf bower_components


### PR DESCRIPTION
Because why not?

Just kidding.

After discussion with Andrew, we agreed that cypress and pupeteer tests are doing the same thing as what is now tested with titella. These tests were also not as accurate as titella, as they are testing demo pages which can get out of date and are not as accurate as testing the live site. Testing is dead. Long live testing (through titella)

Also removing nightwatch tests, as we agreed these don't add much value (we are just rendering a couple of divs!). o-ads is going into maintenance mode. The tests currently pass and we are not making any more active changes to the repo. Similarly the nightwatch config uses fixed versions for browsers so it will not catch any errors on new browser releases (which is also very unlikely).

The tests haven't been removed so that if a cross browser bug crops up in the future for example, we can still run them to help us debug a problem. I've just removed them from the CI build.

This makes the build green and 3 x faster so that we can move rapidly with any urgent fixes that might be needed in the future